### PR TITLE
fix: set default precision and scope for numeric type

### DIFF
--- a/src/pg_schema_column.go
+++ b/src/pg_schema_column.go
@@ -376,6 +376,11 @@ func (pgSchemaColumn *PgSchemaColumn) icebergPrimitiveType() string {
 	case "float4", "float8":
 		return "float"
 	case "numeric":
+		if pgSchemaColumn.NumericPrecision == "0" && pgSchemaColumn.NumericScale == "0" {
+			// As per Postgres documentation a numeric type created without any constraints will follow the implementation limits.
+			// Using limits here as per the table - https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-NUMERIC
+			return "decimal(131072, 16383)"
+		}
 		return "decimal(" + pgSchemaColumn.NumericPrecision + ", " + pgSchemaColumn.NumericScale + ")"
 	case "bool":
 		return "boolean"

--- a/src/pg_schema_column.go
+++ b/src/pg_schema_column.go
@@ -190,6 +190,12 @@ func (pgSchemaColumn *PgSchemaColumn) toParquetSchemaField() ParquetSchemaField 
 			precision = PARQUET_MAX_PRECISION
 		}
 
+		if precision == 0 && scale == 0 {
+			// As per Postgres documentation a numeric type created without any constraints will follow the implementation limits.
+			// Using limits here as per the table - https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-NUMERIC
+			precision = PARQUET_MAX_PRECISION
+			scale = 2
+		}
 		parquetSchemaField.Scale = IntToString(scale)
 		parquetSchemaField.Precision = IntToString(precision)
 		parquetSchemaField.Length = IntToString(scale + precision)
@@ -379,7 +385,7 @@ func (pgSchemaColumn *PgSchemaColumn) icebergPrimitiveType() string {
 		if pgSchemaColumn.NumericPrecision == "0" && pgSchemaColumn.NumericScale == "0" {
 			// As per Postgres documentation a numeric type created without any constraints will follow the implementation limits.
 			// Using limits here as per the table - https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-NUMERIC
-			return "decimal(131072, 16383)"
+			return "decimal(38, 2)"
 		}
 		return "decimal(" + pgSchemaColumn.NumericPrecision + ", " + pgSchemaColumn.NumericScale + ")"
 	case "bool":


### PR DESCRIPTION
# Description

The numeric type in Postgres has precision and scale. If the table column of the `numeric` type doesn't specify precision and scale, the default is (0, 0). This causes all values in the column to become `0`.

This PR sets the precision of numeric to Postgres default specified here: https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-NUMERIC

```
up to 131072 digits before the decimal point; up to 16383 digits after the decimal point
```

# Testing 

Local testing by syncing a table with a numeric column found that the values synced correctly up to 2 precision points.
