### PR TITLE
fix: replace deprecated enable_object_cache with enable_http_metadata_cache

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -108,7 +108,7 @@ func registerFlags() {
 	flag.StringVar(&_config.Database, "database", os.Getenv(ENV_DATABASE), "Database name. Default: \""+DEFAULT_DATABASE+"\"")
 	flag.StringVar(&_config.User, "user", os.Getenv(ENV_USER), "Database user. Default: \""+DEFAULT_USER+"\"")
 	flag.StringVar(&_configParseValues.password, "password", os.Getenv(ENV_PASSWORD), "Database password. Default: \""+DEFAULT_PASSWORD+"\"")
-	flag.BoolVar(&_config.EnableCache, "enable-cache", os.Getenv(ENV_ENABLE_CACHE) == "true", "Enable DuckDB object cache for Parquet metadata. Default: false")
+	flag.BoolVar(&_config.EnableCache, "enable-cache", os.Getenv(ENV_ENABLE_CACHE) == "true", "Enable DuckDB HTTP metadata cache for remote files. Default: false")
 	flag.StringVar(&_config.StoragePath, "storage-path", os.Getenv(ENV_STORAGE_PATH), "Path to the storage folder. Default: \""+DEFAULT_STORAGE_PATH+"\"")
 	flag.StringVar(&_config.LogLevel, "log-level", os.Getenv(ENV_LOG_LEVEL), "Log level: \"ERROR\", \"WARN\", \"INFO\", \"DEBUG\", \"TRACE\". Default: \""+DEFAULT_LOG_LEVEL+"\"")
 	flag.StringVar(&_config.StorageType, "storage-type", os.Getenv(ENV_STORAGE_TYPE), "Storage type: \"LOCAL\", \"S3\". Default: \""+DEFAULT_DB_STORAGE_TYPE+"\"")

--- a/src/duckdb.go
+++ b/src/duckdb.go
@@ -77,9 +77,9 @@ func NewDuckdb(config *Config, withPgCompatibility bool) *Duckdb {
 	}
 
 	if config.EnableCache {
-		_, err = duckdb.ExecContext(ctx, "SET enable_object_cache=true", nil)
+		_, err = duckdb.ExecContext(ctx, "SET enable_http_metadata_cache=true", nil)
 		PanicIfError(config, err)
-		LogInfo(config, "DuckDB: Object cache enabled")
+		LogInfo(config, "DuckDB: HTTP metadata cache enabled")
 	}
 
 	switch config.StorageType {


### PR DESCRIPTION
## Summary
- Replace DuckDB's deprecated `enable_object_cache` (no-op in recent versions) with `enable_http_metadata_cache` for the `--enable-cache` flag
- Update flag description to reflect the new behavior
- `enable_http_metadata_cache` caches HTTP HEAD responses globally, reducing round-trips to S3 for remote file queries

## Test plan
- [ ] Deploy with `--enable-cache` on EKS with S3 storage and verify HTTP metadata caching is active
- [ ] Confirm no regression when `--enable-cache` is not set