### PR TITLE
fix: detect primary keys via pg_catalog instead of information_schema

### DIFF
--- a/src/syncer_table.go
+++ b/src/syncer_table.go
@@ -261,6 +261,10 @@ func (syncer *SyncerTable) pgTableSchemaColumns(conn *pgx.Conn, pgSchemaTable Pg
 
 	var pgSchemaColumns []PgSchemaColumn
 
+	// PKs come from pg_catalog, not information_schema: table_constraints and
+	// key_column_usage omit tables where the user has only SELECT privilege
+	// (per SQL standard), so a read-only sync user would detect no PK and fall
+	// back to the slow keyless all-column merge.
 	rows, err := conn.Query(
 		context.Background(),
 		`SELECT
@@ -274,23 +278,18 @@ func (syncer *SyncerTable) pgTableSchemaColumns(conn *pgx.Conn, pgSchemaTable Pg
 			COALESCE(columns.numeric_scale, 0),
 			COALESCE(columns.datetime_precision, 0),
 			pg_namespace.nspname,
-			CASE WHEN pk.constraint_name IS NOT NULL THEN true ELSE false END
+			CASE WHEN pk.column_name IS NOT NULL THEN true ELSE false END
 		FROM information_schema.columns
 		JOIN pg_type ON pg_type.typname = columns.udt_name
 		JOIN pg_namespace ON pg_namespace.oid = pg_type.typnamespace
 		LEFT JOIN (
-			SELECT
-				tc.constraint_name,
-				kcu.column_name,
-				kcu.table_schema,
-				kcu.table_name
-			FROM information_schema.table_constraints tc
-			JOIN information_schema.key_column_usage kcu
-				ON tc.constraint_name = kcu.constraint_name
-				AND tc.table_schema = kcu.table_schema
-				AND tc.table_name = kcu.table_name
-			WHERE tc.constraint_type = 'PRIMARY KEY'
-		) pk ON pk.column_name = columns.column_name AND pk.table_schema = columns.table_schema AND pk.table_name = columns.table_name
+			SELECT pg_attribute.attname AS column_name
+			FROM pg_constraint
+			JOIN pg_class AS pk_class ON pk_class.oid = pg_constraint.conrelid
+			JOIN pg_namespace AS pk_namespace ON pk_namespace.oid = pk_class.relnamespace
+			JOIN pg_attribute ON pg_attribute.attrelid = pg_constraint.conrelid AND pg_attribute.attnum = ANY(pg_constraint.conkey)
+			WHERE pg_constraint.contype = 'p' AND pk_namespace.nspname = $1 AND pk_class.relname = $2
+		) pk ON pk.column_name = columns.column_name
 		WHERE columns.table_schema = $1 AND columns.table_name = $2
 		ORDER BY array_position($3, columns.column_name)`,
 		pgSchemaTable.Schema,


### PR DESCRIPTION
## Problem

PK detection queried `information_schema.table_constraints` / `key_column_usage`, which — per the SQL standard — omit constraints on tables where the current user has only `SELECT` privilege. A read-only sync user therefore detects no primary key on any table, and the merge falls back to keyless all-column matching. Two consequences:

- **Performance:** overlap checks on resumed syncs compare every column with `IS NOT DISTINCT FROM`, forcing full-file reads (including large text/JSON columns) instead of a single key column — orders of magnitude slower against object storage.
- **Correctness:** all-column matching can't recognize a row that was *updated* between resumed attempts (the old version no longer matches), so both versions survive — duplicate rows.

## Fix

Read PK columns from `pg_catalog` (`pg_constraint` joined to `pg_attribute` via `conkey`), which has no privilege filtering. The subquery is also now scoped to the target table instead of enumerating every PK in the database. Genuinely keyless tables keep the existing all-column fallback.

## Verification

- Reproduced against Postgres 16 in Docker as a `SELECT`-only user: old query returns no PK (the bug); new query correctly returns the PK. Composite PKs return all key columns; keyless tables return none; results as table owner are unchanged.
- Build verified in a `golang:1.24.3` container (matching the Dockerfile).
- Note: the `TestHandleQuery/PG_functions/...jsonb_extract_path_text` test failure pre-exists on the base branch — verified identical on a pristine checkout in the same container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)