### PR TITLE
feat: cap DuckDB parallelism via configurable threads setting

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -46,6 +46,7 @@ const (
 
 	ENV_DUCKDB_MEMORY_LIMIT   = "BEMIDB_DUCKDB_MEMORY_LIMIT"
 	ENV_DUCKDB_TEMP_DIRECTORY = "BEMIDB_DUCKDB_TEMP_DIRECTORY"
+	ENV_DUCKDB_THREADS        = "BEMIDB_DUCKDB_THREADS"
 
 	ENV_PARQUET_ROW_GROUP_SIZE_MB    = "BEMIDB_PARQUET_ROW_GROUP_SIZE_MB"
 	ENV_PARQUET_PAYLOAD_THRESHOLD_MB = "BEMIDB_PARQUET_PAYLOAD_THRESHOLD_MB"
@@ -98,6 +99,7 @@ type Config struct {
 	EnableHttpConnectionCache bool
 	DuckDbMemoryLimit         string
 	DuckDbTempDirectory       string
+	DuckDbThreads             int
 	ParquetRowGroupSizeMb     int
 	ParquetPayloadThresholdMb int
 	LogLevel                  string
@@ -132,6 +134,7 @@ func registerFlags() {
 	flag.BoolVar(&_config.EnableHttpConnectionCache, "enable-http-connection-cache", os.Getenv(ENV_ENABLE_HTTP_CONNECTION_CACHE) == "true", "Enable DuckDB HTTP connection keep-alive for remote files. Default: false")
 	flag.StringVar(&_config.DuckDbMemoryLimit, "duckdb-memory-limit", os.Getenv(ENV_DUCKDB_MEMORY_LIMIT), "(Optional) DuckDB memory_limit, e.g. \"4GB\". Bounds DuckDB memory; it spills to the temp directory when exceeded. Set below the container memory limit.")
 	flag.StringVar(&_config.DuckDbTempDirectory, "duckdb-temp-directory", os.Getenv(ENV_DUCKDB_TEMP_DIRECTORY), "(Optional) DuckDB temp_directory for spilling to disk. Defaults to the OS temp dir so a memory limit can spill instead of erroring.")
+	flag.IntVar(&_config.DuckDbThreads, "duckdb-threads", intFromEnv(ENV_DUCKDB_THREADS), "(Optional) DuckDB threads. Caps scan parallelism to bound peak memory. Defaults to DuckDB's own default (all host cores).")
 	flag.IntVar(&_config.ParquetRowGroupSizeMb, "parquet-row-group-size-mb", intFromEnv(ENV_PARQUET_ROW_GROUP_SIZE_MB), "(Optional) Parquet row group size in MB. Smaller values cap the in-memory write buffer. Default: 128")
 	flag.IntVar(&_config.ParquetPayloadThresholdMb, "parquet-payload-threshold-mb", intFromEnv(ENV_PARQUET_PAYLOAD_THRESHOLD_MB), "(Optional) Uncompressed payload (MB) per Parquet file before rolling to a new file. Default: 2048")
 	flag.StringVar(&_config.StoragePath, "storage-path", os.Getenv(ENV_STORAGE_PATH), "Path to the storage folder. Default: \""+DEFAULT_STORAGE_PATH+"\"")

--- a/src/duckdb.go
+++ b/src/duckdb.go
@@ -92,6 +92,15 @@ func NewDuckdb(config *Config, withPgCompatibility bool) *Duckdb {
 		LogInfo(config, "DuckDB: memory_limit set to", config.DuckDbMemoryLimit, "(temp_directory:", config.DuckDbTempDirectory+")")
 	}
 
+	// Cap DuckDB parallelism. Threads default to all host cores — the node's, not the
+	// container's, since cgroup CPU limits are ignored — and peak scan memory grows with
+	// every worker holding its own decompressed row-group chunks.
+	if config.DuckDbThreads > 0 {
+		_, err = duckdb.ExecContext(ctx, "SET threads="+IntToString(config.DuckDbThreads), nil)
+		PanicIfError(config, err)
+		LogInfo(config, "DuckDB: threads set to", config.DuckDbThreads)
+	}
+
 	if config.EnableCache {
 		_, err = duckdb.ExecContext(ctx, "SET enable_object_cache=true", nil)
 		PanicIfError(config, err)


### PR DESCRIPTION
## Problem

DuckDB defaults its worker-thread count to all host CPU cores — in containerized deployments that means the *node's* cores, not the container's, since cgroup CPU limits are ignored. During scans, each worker holds its own decompressed row-group chunks, so peak memory scales with the thread count. On tables with megabyte-sized values, wide scans can exhaust `memory_limit` (query errors) or push the process past the container memory limit (OOM kill) — DuckDB's own OOM message suggests `SET threads=X` as a remedy, but there was no way to configure it.

## Fix

New `--duckdb-threads` flag / `BEMIDB_DUCKDB_THREADS` env var, applied as a `SET threads=N` boot query — mirroring the existing `memory_limit` pattern. Unset keeps DuckDB's default behavior.

## Verification

- `SET threads=N` + `current_setting('threads')` validated against DuckDB CLI.
- Build verified in a `golang:1.24.3` container (matching the Dockerfile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)