### PR TITLE
fix: bound result-set memory via a byte cap (--max-result-mb)

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -47,6 +47,7 @@ const (
 	ENV_DUCKDB_MEMORY_LIMIT   = "BEMIDB_DUCKDB_MEMORY_LIMIT"
 	ENV_DUCKDB_TEMP_DIRECTORY = "BEMIDB_DUCKDB_TEMP_DIRECTORY"
 	ENV_DUCKDB_THREADS        = "BEMIDB_DUCKDB_THREADS"
+	ENV_MAX_RESULT_MB         = "BEMIDB_MAX_RESULT_MB"
 
 	ENV_PARQUET_ROW_GROUP_SIZE_MB    = "BEMIDB_PARQUET_ROW_GROUP_SIZE_MB"
 	ENV_PARQUET_PAYLOAD_THRESHOLD_MB = "BEMIDB_PARQUET_PAYLOAD_THRESHOLD_MB"
@@ -100,6 +101,7 @@ type Config struct {
 	DuckDbMemoryLimit         string
 	DuckDbTempDirectory       string
 	DuckDbThreads             int
+	MaxResultMb               int
 	ParquetRowGroupSizeMb     int
 	ParquetPayloadThresholdMb int
 	LogLevel                  string
@@ -135,6 +137,7 @@ func registerFlags() {
 	flag.StringVar(&_config.DuckDbMemoryLimit, "duckdb-memory-limit", os.Getenv(ENV_DUCKDB_MEMORY_LIMIT), "(Optional) DuckDB memory_limit, e.g. \"4GB\". Bounds DuckDB memory; it spills to the temp directory when exceeded. Set below the container memory limit.")
 	flag.StringVar(&_config.DuckDbTempDirectory, "duckdb-temp-directory", os.Getenv(ENV_DUCKDB_TEMP_DIRECTORY), "(Optional) DuckDB temp_directory for spilling to disk. Defaults to the OS temp dir so a memory limit can spill instead of erroring.")
 	flag.IntVar(&_config.DuckDbThreads, "duckdb-threads", intFromEnv(ENV_DUCKDB_THREADS), "(Optional) DuckDB threads. Caps scan parallelism to bound peak memory. Defaults to DuckDB's own default (all host cores).")
+	flag.IntVar(&_config.MaxResultMb, "max-result-mb", intFromEnv(ENV_MAX_RESULT_MB), "(Optional) Maximum result payload in MB per query. Results are buffered in memory before sending, so unbounded results can OOM the process. 0 disables the cap.")
 	flag.IntVar(&_config.ParquetRowGroupSizeMb, "parquet-row-group-size-mb", intFromEnv(ENV_PARQUET_ROW_GROUP_SIZE_MB), "(Optional) Parquet row group size in MB. Smaller values cap the in-memory write buffer. Default: 128")
 	flag.IntVar(&_config.ParquetPayloadThresholdMb, "parquet-payload-threshold-mb", intFromEnv(ENV_PARQUET_PAYLOAD_THRESHOLD_MB), "(Optional) Uncompressed payload (MB) per Parquet file before rolling to a new file. Default: 2048")
 	flag.StringVar(&_config.StoragePath, "storage-path", os.Getenv(ENV_STORAGE_PATH), "Path to the storage folder. Default: \""+DEFAULT_STORAGE_PATH+"\"")

--- a/src/config.go
+++ b/src/config.go
@@ -161,6 +161,12 @@ func registerFlags() {
 func parseFlags() {
 	flag.Parse()
 
+	// Fail fast: a negative value would silently disable the cap while the
+	// operator believes they are protected.
+	if _config.MaxResultMb < 0 {
+		panic("--max-result-mb (BEMIDB_MAX_RESULT_MB) must be >= 0, got " + IntToString(_config.MaxResultMb))
+	}
+
 	if _config.Host == "" {
 		_config.Host = DEFAULT_HOST
 	}

--- a/src/init_test.go
+++ b/src/init_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"os"
+	"testing"
 )
 
 var PUBLIC_SCHEMA_TEST_TABLE_PG_SCHEMA_COLUMNS = []PgSchemaColumn{
@@ -417,7 +418,28 @@ func init() {
 	}
 }
 
+// os.Args is shared by two flag parsers that want different contents: LoadConfig
+// (BemiDB flags only — a -test.* flag makes its ExitOnError FlagSet abort) and the
+// testing framework (-test.* flags — without them every `go test -run` filter is
+// silently discarded, all tests always run, and a panic in the first test aborts
+// the whole binary). loadTestConfig runs from init(), before the testing framework
+// parses, so it scrubs and then restores; TestMain then parses the -test.* flags
+// and scrubs permanently for tests that call LoadConfig directly.
+func TestMain(m *testing.M) {
+	testing.Init()
+	flag.Parse()
+	setTestArgs([]string{})
+	os.Exit(m.Run())
+}
+
 func loadTestConfig() *Config {
+	originalArgs := os.Args
+	originalCommandLine := flag.CommandLine
+	defer func() {
+		os.Args = originalArgs
+		flag.CommandLine = originalCommandLine
+	}()
+
 	setTestArgs([]string{})
 
 	config := LoadConfig(true)

--- a/src/postgres.go
+++ b/src/postgres.go
@@ -156,6 +156,10 @@ func (postgres *Postgres) handleExtendedQuery(queryHandler *QueryHandler, parseM
 			}
 			postgres.writeMessages(messages...)
 		case *pgproto3.Close:
+			if previousErr != nil { // Skip processing the next message if there was an error in the previous message
+				continue
+			}
+
 			LogDebug(postgres.config, "Closing", string(message.ObjectType), message.Name)
 			if preparedStatement.Rows != nil {
 				preparedStatement.Rows.Close()

--- a/src/postgres.go
+++ b/src/postgres.go
@@ -155,8 +155,19 @@ func (postgres *Postgres) handleExtendedQuery(queryHandler *QueryHandler, parseM
 				previousErr = err
 			}
 			postgres.writeMessages(messages...)
+		case *pgproto3.Close:
+			LogDebug(postgres.config, "Closing", string(message.ObjectType), message.Name)
+			if preparedStatement.Rows != nil {
+				preparedStatement.Rows.Close()
+			}
+			postgres.writeMessages(&pgproto3.CloseComplete{})
 		case *pgproto3.Sync:
 			LogDebug(postgres.config, "Syncing query")
+			// Release rows left open by a suspended portal (Execute.MaxRows) or a
+			// Describe that was never followed by Execute. Close is idempotent.
+			if preparedStatement.Rows != nil {
+				preparedStatement.Rows.Close()
+			}
 			postgres.writeMessages(
 				&pgproto3.ReadyForQuery{TxStatus: PG_TX_STATUS_IDLE},
 			)

--- a/src/postgres.go
+++ b/src/postgres.go
@@ -167,9 +167,11 @@ func (postgres *Postgres) handleExtendedQuery(queryHandler *QueryHandler, parseM
 			postgres.writeMessages(&pgproto3.CloseComplete{})
 		case *pgproto3.Sync:
 			LogDebug(postgres.config, "Syncing query")
-			// Release rows left open by a suspended portal (Execute.MaxRows) or a
-			// Describe that was never followed by Execute. Close is idempotent.
-			if preparedStatement.Rows != nil {
+			// Sync must always respond, so unlike the guarded cases above it runs
+			// even after an error — when a Bind/Describe failure has left
+			// preparedStatement nil. Guard the pointer, then release rows left open
+			// by a Describe that was never followed by Execute (Close is idempotent).
+			if preparedStatement != nil && preparedStatement.Rows != nil {
 				preparedStatement.Rows.Close()
 			}
 			postgres.writeMessages(

--- a/src/postgres_test.go
+++ b/src/postgres_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgproto3"
+)
+
+// TestRunDoesNotPanicOnErrorBeforeSync drives the exact extended-protocol
+// sequence that used to crash the process: a parameterized query whose Bind/
+// Describe fails leaves preparedStatement nil, and the following Sync — which
+// must always respond — previously dereferenced it (SIGSEGV in the per-connection
+// goroutine, killing the whole server for every client). The server must instead
+// return an ErrorResponse and stay alive.
+func TestRunDoesNotPanicOnErrorBeforeSync(t *testing.T) {
+	createTestTables(t)
+	queryHandler := initQueryHandler()
+	defer queryHandler.duckdb.Close()
+
+	// A real loopback socket (not net.Pipe): net.Pipe is unbuffered, so the server
+	// writing a reply while the client is still flushing later messages deadlocks.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+
+	done := make(chan struct{})
+	go func() {
+		serverConn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			close(done)
+			return
+		}
+		postgres := NewPostgres(queryHandler.config, &serverConn)
+		postgres.Run(queryHandler) // must return normally, not panic
+		serverConn.Close()
+		close(done)
+	}()
+
+	clientConn, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer clientConn.Close()
+
+	frontend := pgproto3.NewFrontend(clientConn, clientConn)
+	frontend.Send(&pgproto3.StartupMessage{
+		ProtocolVersion: pgproto3.ProtocolVersionNumber,
+		Parameters:      map[string]string{"user": "bemidb", "database": "bemidb"},
+	})
+	if err := frontend.Flush(); err != nil {
+		t.Fatalf("startup flush: %v", err)
+	}
+	for {
+		msg, err := frontend.Receive()
+		if err != nil {
+			t.Fatalf("startup receive: %v", err)
+		}
+		if _, ok := msg.(*pgproto3.ReadyForQuery); ok {
+			break
+		}
+	}
+
+	// Bind binds a non-numeric value to $1::int; the cast error surfaces at
+	// Describe (which executes the query), leaving preparedStatement nil.
+	frontend.Send(&pgproto3.Parse{Query: "SELECT $1::int"})
+	frontend.Send(&pgproto3.Bind{Parameters: [][]byte{[]byte("not_a_number")}, ParameterFormatCodes: []int16{0}})
+	frontend.Send(&pgproto3.Describe{ObjectType: 'P'})
+	frontend.Send(&pgproto3.Execute{})
+	frontend.Send(&pgproto3.Sync{})
+	if err := frontend.Flush(); err != nil {
+		t.Fatalf("extended flush: %v", err)
+	}
+
+	sawError := false
+	for {
+		msg, err := frontend.Receive()
+		if err != nil {
+			t.Fatalf("expected ErrorResponse then ReadyForQuery, got receive error (server likely crashed): %v", err)
+		}
+		if _, ok := msg.(*pgproto3.ErrorResponse); ok {
+			sawError = true
+		}
+		if _, ok := msg.(*pgproto3.ReadyForQuery); ok {
+			break
+		}
+	}
+	if !sawError {
+		t.Errorf("expected an ErrorResponse for the bad parameter")
+	}
+
+	// The connection loop must still be alive and serving: a Terminate ends it
+	// cleanly and Run returns (a crashed goroutine would never close done).
+	frontend.Send(&pgproto3.Terminate{})
+	_ = frontend.Flush()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Run did not return after Terminate — connection loop wedged or panicked")
+	}
+}

--- a/src/postgres_test.go
+++ b/src/postgres_test.go
@@ -45,6 +45,11 @@ func TestRunDoesNotPanicOnErrorBeforeSync(t *testing.T) {
 		t.Fatalf("dial: %v", err)
 	}
 	defer clientConn.Close()
+	// Bound every read/write: without a deadline, a server that wedges before
+	// replying leaves frontend.Receive() blocked until go test's global timeout.
+	if err := clientConn.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
 
 	frontend := pgproto3.NewFrontend(clientConn, clientConn)
 	frontend.Send(&pgproto3.StartupMessage{
@@ -93,7 +98,8 @@ func TestRunDoesNotPanicOnErrorBeforeSync(t *testing.T) {
 	}
 
 	// The connection loop must still be alive and serving: a Terminate ends it
-	// cleanly and Run returns (a crashed goroutine would never close done).
+	// cleanly and Run returns. (A regression panic would crash the whole test
+	// process outright; the timeout below guards the wedged-but-alive case.)
 	frontend.Send(&pgproto3.Terminate{})
 	_ = frontend.Flush()
 	select {

--- a/src/query_handler.go
+++ b/src/query_handler.go
@@ -301,7 +301,7 @@ func (queryHandler *QueryHandler) HandleSimpleQuery(originalQuery string) ([]pgp
 			return nil, err
 		}
 		queryMessages = append(queryMessages, descriptionMessages...)
-		dataMessages, err := queryHandler.rowsToDataMessages(rows, originalQueryStatements[i])
+		dataMessages, _, err := queryHandler.rowsToDataMessages(rows, originalQueryStatements[i], 0)
 		if err != nil {
 			return nil, err
 		}
@@ -472,9 +472,21 @@ func (queryHandler *QueryHandler) HandleExecuteQuery(message *pgproto3.Execute, 
 		preparedStatement.Rows = rows
 	}
 
-	defer preparedStatement.Rows.Close()
-
-	return queryHandler.rowsToDataMessages(preparedStatement.Rows, preparedStatement.OriginalQuery)
+	messages, suspended, err := queryHandler.rowsToDataMessages(preparedStatement.Rows, preparedStatement.OriginalQuery, message.MaxRows)
+	if suspended {
+		// The portal hit the client-requested row limit (Execute.MaxRows, e.g. JDBC
+		// setMaxRows/setFetchSize) with rows possibly remaining. Keep Rows open: a
+		// follow-up Execute on this portal resumes via the Rows != nil branch above.
+		// Sync and Close clean up if the client never resumes.
+		return messages, nil
+	}
+	// Close but keep the Rows pointer: re-Executing a completed portal must return
+	// zero rows (closed rows iterate as empty), not re-run the query.
+	preparedStatement.Rows.Close()
+	if err != nil {
+		return nil, err
+	}
+	return messages, nil
 }
 
 func (queryHandler *QueryHandler) createSchemas() {
@@ -508,19 +520,45 @@ func (queryHandler *QueryHandler) rowsToDescriptionMessages(rows *sql.Rows, orig
 	return messages, nil
 }
 
-func (queryHandler *QueryHandler) rowsToDataMessages(rows *sql.Rows, originalQuery string) ([]pgproto3.Message, error) {
+// rowsToDataMessages buffers the whole result in memory before it is written to the
+// connection, so it enforces the two result-size bounds: the client-requested row
+// limit from Execute.MaxRows (0 = unlimited; on hitting it the portal is suspended
+// and the second return value is true), and the byte cap from --max-result-mb
+// (0 = disabled; exceeding it fails the query).
+func (queryHandler *QueryHandler) rowsToDataMessages(rows *sql.Rows, originalQuery string, maxRows uint32) ([]pgproto3.Message, bool, error) {
 	cols, err := rows.ColumnTypes()
 	if err != nil {
-		return nil, fmt.Errorf("couldn't get column types: %w. Original query: %s", err, originalQuery)
+		return nil, false, fmt.Errorf("couldn't get column types: %w. Original query: %s", err, originalQuery)
 	}
+
+	maxResultBytes := int64(queryHandler.config.MaxResultMb) * 1024 * 1024
+	var resultBytes int64
+	var rowCount uint32
 
 	var messages []pgproto3.Message
 	for rows.Next() {
 		dataRow, err := queryHandler.generateDataRow(rows, cols)
 		if err != nil {
-			return nil, fmt.Errorf("couldn't get data row: %w. Original query: %s", err, originalQuery)
+			return nil, false, fmt.Errorf("couldn't get data row: %w. Original query: %s", err, originalQuery)
 		}
 		messages = append(messages, dataRow)
+
+		if maxResultBytes > 0 {
+			for _, value := range dataRow.Values {
+				resultBytes += int64(len(value))
+			}
+			if resultBytes > maxResultBytes {
+				return nil, false, fmt.Errorf("result exceeded the %d MB limit (BEMIDB_MAX_RESULT_MB); add a LIMIT or select fewer columns. Original query: %s", queryHandler.config.MaxResultMb, originalQuery)
+			}
+		}
+
+		if maxRows > 0 {
+			rowCount++
+			if rowCount == maxRows {
+				messages = append(messages, &pgproto3.PortalSuspended{})
+				return messages, true, nil
+			}
+		}
 	}
 
 	commandTag := FALLBACK_SQL_QUERY
@@ -537,7 +575,7 @@ func (queryHandler *QueryHandler) rowsToDataMessages(rows *sql.Rows, originalQue
 	}
 
 	messages = append(messages, &pgproto3.CommandComplete{CommandTag: []byte(commandTag)})
-	return messages, nil
+	return messages, false, nil
 }
 
 func (queryHandler *QueryHandler) generateRowDescription(cols []*sql.ColumnType) *pgproto3.RowDescription {

--- a/src/query_handler.go
+++ b/src/query_handler.go
@@ -275,6 +275,9 @@ func (queryHandler *QueryHandler) HandleSimpleQuery(originalQuery string) ([]pgp
 	}
 
 	var queriesMessages []pgproto3.Message
+	// One byte budget across ALL statements: they accumulate into a single buffer
+	// below, so a per-statement budget would multiply the cap by the statement count.
+	var resultBytes int64
 
 	for i, queryStatement := range queryStatements {
 		rows, err := queryHandler.duckdb.QueryContext(context.Background(), queryStatement)
@@ -301,10 +304,11 @@ func (queryHandler *QueryHandler) HandleSimpleQuery(originalQuery string) ([]pgp
 			return nil, err
 		}
 		queryMessages = append(queryMessages, descriptionMessages...)
-		dataMessages, _, err := queryHandler.rowsToDataMessages(rows, originalQueryStatements[i], 0)
+		dataMessages, updatedResultBytes, err := queryHandler.rowsToDataMessages(rows, originalQueryStatements[i], resultBytes)
 		if err != nil {
 			return nil, err
 		}
+		resultBytes = updatedResultBytes
 		queryMessages = append(queryMessages, dataMessages...)
 
 		queriesMessages = append(queriesMessages, queryMessages...)
@@ -347,6 +351,14 @@ func (queryHandler *QueryHandler) HandleParseQuery(message *pgproto3.Parse) ([]p
 func (queryHandler *QueryHandler) HandleBindQuery(message *pgproto3.Bind, preparedStatement *PreparedStatement) ([]pgproto3.Message, *PreparedStatement, error) {
 	if message.PreparedStatement != preparedStatement.Name {
 		return nil, nil, fmt.Errorf("prepared statement mismatch, %s instead of %s: %s", message.PreparedStatement, preparedStatement.Name, preparedStatement.OriginalQuery)
+	}
+
+	// Bind creates a new portal: results from a previous Bind/Describe of this
+	// statement must not leak into it. Without this reset, a follow-up Execute
+	// reuses the old (possibly consumed) rows via the Rows != nil branch.
+	if preparedStatement.Rows != nil {
+		preparedStatement.Rows.Close()
+		preparedStatement.Rows = nil
 	}
 
 	var variables []interface{}
@@ -472,21 +484,16 @@ func (queryHandler *QueryHandler) HandleExecuteQuery(message *pgproto3.Execute, 
 		preparedStatement.Rows = rows
 	}
 
-	messages, suspended, err := queryHandler.rowsToDataMessages(preparedStatement.Rows, preparedStatement.OriginalQuery, message.MaxRows)
-	if suspended {
-		// The portal hit the client-requested row limit (Execute.MaxRows, e.g. JDBC
-		// setMaxRows/setFetchSize) with rows possibly remaining. Keep Rows open: a
-		// follow-up Execute on this portal resumes via the Rows != nil branch above.
-		// Sync and Close clean up if the client never resumes.
-		return messages, nil
-	}
-	// Close but keep the Rows pointer: re-Executing a completed portal must return
-	// zero rows (closed rows iterate as empty), not re-run the query.
-	preparedStatement.Rows.Close()
-	if err != nil {
-		return nil, err
-	}
-	return messages, nil
+	defer preparedStatement.Rows.Close()
+
+	// Execute.MaxRows (sent by e.g. JDBC setMaxRows/setFetchSize) is deliberately
+	// NOT honored: doing it correctly requires portal suspension that survives Sync,
+	// which the one-exchange-per-Parse connection loop cannot support — emitting
+	// PortalSuspended without that support kills cursor-mode clients on their resume.
+	// Clients receive the full result and truncate client-side (pre-existing
+	// behavior); oversized results are bounded server-side by --max-result-mb.
+	messages, _, err := queryHandler.rowsToDataMessages(preparedStatement.Rows, preparedStatement.OriginalQuery, 0)
+	return messages, err
 }
 
 func (queryHandler *QueryHandler) createSchemas() {
@@ -520,43 +527,44 @@ func (queryHandler *QueryHandler) rowsToDescriptionMessages(rows *sql.Rows, orig
 	return messages, nil
 }
 
-// rowsToDataMessages buffers the whole result in memory before it is written to the
-// connection, so it enforces the two result-size bounds: the client-requested row
-// limit from Execute.MaxRows (0 = unlimited; on hitting it the portal is suspended
-// and the second return value is true), and the byte cap from --max-result-mb
-// (0 = disabled; exceeding it fails the query).
-func (queryHandler *QueryHandler) rowsToDataMessages(rows *sql.Rows, originalQuery string, maxRows uint32) ([]pgproto3.Message, bool, error) {
+// Estimated heap cost per buffered row beyond raw cell bytes: the DataRow struct,
+// its [][]byte backing array (NULL cells included), one allocation per non-NULL
+// cell, and the messages slice entry. Deliberate overestimates so the cap errs on
+// the safe side; the true multiplier for narrow rows is what matters, not the
+// exact constant.
+const resultBytesPerRowOverhead = 64
+const resultBytesPerCellOverhead = 48
+
+// rowsToDataMessages buffers the whole result in memory before it is written to
+// the connection, so it enforces the --max-result-mb byte cap (0 = disabled):
+// this buffer is the process's largest unbounded allocation, and the pod's OOM
+// killer is the only alternative enforcement. startResultBytes threads one shared
+// budget across the statements of a simple-protocol query; the returned int64 is
+// the updated total.
+func (queryHandler *QueryHandler) rowsToDataMessages(rows *sql.Rows, originalQuery string, startResultBytes int64) ([]pgproto3.Message, int64, error) {
 	cols, err := rows.ColumnTypes()
 	if err != nil {
-		return nil, false, fmt.Errorf("couldn't get column types: %w. Original query: %s", err, originalQuery)
+		return nil, startResultBytes, fmt.Errorf("couldn't get column types: %w. Original query: %s", err, originalQuery)
 	}
 
 	maxResultBytes := int64(queryHandler.config.MaxResultMb) * 1024 * 1024
-	var resultBytes int64
-	var rowCount uint32
+	resultBytes := startResultBytes
 
 	var messages []pgproto3.Message
 	for rows.Next() {
 		dataRow, err := queryHandler.generateDataRow(rows, cols)
 		if err != nil {
-			return nil, false, fmt.Errorf("couldn't get data row: %w. Original query: %s", err, originalQuery)
+			return nil, resultBytes, fmt.Errorf("couldn't get data row: %w. Original query: %s", err, originalQuery)
 		}
 		messages = append(messages, dataRow)
 
 		if maxResultBytes > 0 {
+			resultBytes += resultBytesPerRowOverhead + int64(len(dataRow.Values))*resultBytesPerCellOverhead
 			for _, value := range dataRow.Values {
 				resultBytes += int64(len(value))
 			}
 			if resultBytes > maxResultBytes {
-				return nil, false, fmt.Errorf("result exceeded the %d MB limit (BEMIDB_MAX_RESULT_MB); add a LIMIT or select fewer columns. Original query: %s", queryHandler.config.MaxResultMb, originalQuery)
-			}
-		}
-
-		if maxRows > 0 {
-			rowCount++
-			if rowCount == maxRows {
-				messages = append(messages, &pgproto3.PortalSuspended{})
-				return messages, true, nil
+				return nil, resultBytes, fmt.Errorf("result exceeded the %d MB limit (BEMIDB_MAX_RESULT_MB); add a LIMIT or select fewer columns. Original query: %s", queryHandler.config.MaxResultMb, originalQuery)
 			}
 		}
 	}
@@ -575,7 +583,7 @@ func (queryHandler *QueryHandler) rowsToDataMessages(rows *sql.Rows, originalQue
 	}
 
 	messages = append(messages, &pgproto3.CommandComplete{CommandTag: []byte(commandTag)})
-	return messages, false, nil
+	return messages, resultBytes, nil
 }
 
 func (queryHandler *QueryHandler) generateRowDescription(cols []*sql.ColumnType) *pgproto3.RowDescription {

--- a/src/query_handler.go
+++ b/src/query_handler.go
@@ -304,9 +304,11 @@ func (queryHandler *QueryHandler) HandleSimpleQuery(originalQuery string) ([]pgp
 			return nil, err
 		}
 		queryMessages = append(queryMessages, descriptionMessages...)
-		// Description messages accumulate into the same single-flush buffer as data
-		// rows, so they count against the shared budget too.
-		resultBytes += encodedMessagesBytes(descriptionMessages)
+		if queryHandler.config.MaxResultMb > 0 {
+			// Description messages accumulate into the same single-flush buffer as data
+			// rows, so they count against the shared budget too.
+			resultBytes += encodedMessagesBytes(descriptionMessages)
+		}
 		dataMessages, updatedResultBytes, err := queryHandler.rowsToDataMessages(rows, originalQueryStatements[i], resultBytes)
 		if err != nil {
 			return nil, err
@@ -352,16 +354,18 @@ func (queryHandler *QueryHandler) HandleParseQuery(message *pgproto3.Parse) ([]p
 }
 
 func (queryHandler *QueryHandler) HandleBindQuery(message *pgproto3.Bind, preparedStatement *PreparedStatement) ([]pgproto3.Message, *PreparedStatement, error) {
-	if message.PreparedStatement != preparedStatement.Name {
-		return nil, nil, fmt.Errorf("prepared statement mismatch, %s instead of %s: %s", message.PreparedStatement, preparedStatement.Name, preparedStatement.OriginalQuery)
-	}
-
 	// Bind creates a new portal: results from a previous Bind/Describe of this
-	// statement must not leak into it. Without this reset, a follow-up Execute
-	// reuses the old (possibly consumed) rows via the Rows != nil branch.
+	// statement must not leak into it (a follow-up Execute would reuse them via
+	// the Rows != nil branch). This must run before every error return: on error
+	// the caller nils the statement, orphaning still-open rows beyond the reach
+	// of Sync's cleanup.
 	if preparedStatement.Rows != nil {
 		preparedStatement.Rows.Close()
 		preparedStatement.Rows = nil
+	}
+
+	if message.PreparedStatement != preparedStatement.Name {
+		return nil, nil, fmt.Errorf("prepared statement mismatch, %s instead of %s: %s", message.PreparedStatement, preparedStatement.Name, preparedStatement.OriginalQuery)
 	}
 
 	var variables []interface{}
@@ -441,6 +445,15 @@ func castTextParam(text string, parameterOIDs []uint32, index int) (interface{},
 }
 
 func (queryHandler *QueryHandler) HandleDescribeQuery(message *pgproto3.Describe, preparedStatement *PreparedStatement) ([]pgproto3.Message, *PreparedStatement, error) {
+	// A repeat Describe would otherwise leak the prior result handle until GC
+	// (mirrors the reset in HandleBindQuery). Like there, this must run before
+	// every error return: on error the caller nils the statement, orphaning
+	// still-open rows beyond the reach of Sync's cleanup.
+	if preparedStatement.Rows != nil {
+		preparedStatement.Rows.Close()
+		preparedStatement.Rows = nil
+	}
+
 	switch message.ObjectType {
 	case 'S': // Statement
 		if message.Name != preparedStatement.Name {
@@ -455,13 +468,6 @@ func (queryHandler *QueryHandler) HandleDescribeQuery(message *pgproto3.Describe
 	preparedStatement.Described = true
 	if preparedStatement.Query == "" || !preparedStatement.Bound { // Empty query or Parse->[No Bind]->Describe
 		return []pgproto3.Message{&pgproto3.NoData{}}, preparedStatement, nil
-	}
-
-	// A repeat Describe of the same portal would otherwise leak the prior result
-	// handle until GC (mirrors the reset in HandleBindQuery).
-	if preparedStatement.Rows != nil {
-		preparedStatement.Rows.Close()
-		preparedStatement.Rows = nil
 	}
 
 	rows, err := preparedStatement.Statement.QueryContext(context.Background(), preparedStatement.Variables...)

--- a/src/query_handler.go
+++ b/src/query_handler.go
@@ -304,6 +304,9 @@ func (queryHandler *QueryHandler) HandleSimpleQuery(originalQuery string) ([]pgp
 			return nil, err
 		}
 		queryMessages = append(queryMessages, descriptionMessages...)
+		// Description messages accumulate into the same single-flush buffer as data
+		// rows, so they count against the shared budget too.
+		resultBytes += encodedMessagesBytes(descriptionMessages)
 		dataMessages, updatedResultBytes, err := queryHandler.rowsToDataMessages(rows, originalQueryStatements[i], resultBytes)
 		if err != nil {
 			return nil, err
@@ -454,6 +457,13 @@ func (queryHandler *QueryHandler) HandleDescribeQuery(message *pgproto3.Describe
 		return []pgproto3.Message{&pgproto3.NoData{}}, preparedStatement, nil
 	}
 
+	// A repeat Describe of the same portal would otherwise leak the prior result
+	// handle until GC (mirrors the reset in HandleBindQuery).
+	if preparedStatement.Rows != nil {
+		preparedStatement.Rows.Close()
+		preparedStatement.Rows = nil
+	}
+
 	rows, err := preparedStatement.Statement.QueryContext(context.Background(), preparedStatement.Variables...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("couldn't execute statement: %w. Original query: %s", err, preparedStatement.OriginalQuery)
@@ -527,6 +537,21 @@ func (queryHandler *QueryHandler) rowsToDescriptionMessages(rows *sql.Rows, orig
 	return messages, nil
 }
 
+// encodedMessagesBytes returns the wire size of already-built messages, used to
+// count RowDescriptions against the result budget. Called only for the few, small
+// description messages per statement — not for data rows, which are measured
+// inline in rowsToDataMessages.
+func encodedMessagesBytes(messages []pgproto3.Message) int64 {
+	var total int64
+	for _, message := range messages {
+		buf, err := message.Encode(nil)
+		if err == nil {
+			total += int64(len(buf))
+		}
+	}
+	return total
+}
+
 // Estimated heap cost per buffered row beyond raw cell bytes: the DataRow struct,
 // its [][]byte backing array (NULL cells included), one allocation per non-NULL
 // cell, and the messages slice entry. Deliberate overestimates so the cap errs on
@@ -549,6 +574,13 @@ func (queryHandler *QueryHandler) rowsToDataMessages(rows *sql.Rows, originalQue
 
 	maxResultBytes := int64(queryHandler.config.MaxResultMb) * 1024 * 1024
 	resultBytes := startResultBytes
+
+	// Catch a result already over budget from prior statements' rows or from wide
+	// RowDescriptions, even when this statement yields no rows (the per-row check
+	// below would never run).
+	if maxResultBytes > 0 && resultBytes > maxResultBytes {
+		return nil, resultBytes, fmt.Errorf("result exceeded the %d MB limit (BEMIDB_MAX_RESULT_MB); add a LIMIT or select fewer columns. Original query: %s", queryHandler.config.MaxResultMb, originalQuery)
+	}
 
 	var messages []pgproto3.Message
 	for rows.Next() {

--- a/src/query_handler_test.go
+++ b/src/query_handler_test.go
@@ -1733,18 +1733,20 @@ func testResponseByQuery(t *testing.T, queryHandler *QueryHandler, responseByQue
 	}
 }
 
-func TestHandleExecuteQueryWithMaxRows(t *testing.T) {
+func TestHandleExecuteQueryIgnoresMaxRows(t *testing.T) {
 	createTestTables(t)
 	queryHandler := initQueryHandler()
 	defer queryHandler.duckdb.Close()
 
-	t.Run("Suspends the portal at Execute.MaxRows and resumes until completion", func(t *testing.T) {
+	t.Run("Returns the full result and CommandComplete even when Execute.MaxRows is set", func(t *testing.T) {
+		// Honoring MaxRows requires portal suspension that survives Sync, which the
+		// connection loop does not support. This pins the deliberate behavior:
+		// ignore the row cap, never emit PortalSuspended (a resume invitation the
+		// server cannot honor), and rely on --max-result-mb for memory safety.
 		parseMessage := &pgproto3.Parse{Query: "SELECT i FROM (VALUES (1), (2), (3), (4), (5)) AS t(i)"}
 		_, preparedStatement, err := queryHandler.HandleParseQuery(parseMessage)
 		testNoError(t, err)
 		_, preparedStatement, err = queryHandler.HandleBindQuery(&pgproto3.Bind{}, preparedStatement)
-		testNoError(t, err)
-		_, preparedStatement, err = queryHandler.HandleDescribeQuery(&pgproto3.Describe{ObjectType: 'P'}, preparedStatement)
 		testNoError(t, err)
 
 		messages, err := queryHandler.HandleExecuteQuery(&pgproto3.Execute{MaxRows: 2}, preparedStatement)
@@ -1752,46 +1754,65 @@ func TestHandleExecuteQueryWithMaxRows(t *testing.T) {
 		testMessageTypes(t, messages, []pgproto3.Message{
 			&pgproto3.DataRow{},
 			&pgproto3.DataRow{},
-			&pgproto3.PortalSuspended{},
-		})
-		if preparedStatement.Rows == nil {
-			t.Errorf("Expected the suspended portal to keep its rows open")
-		}
-
-		messages, err = queryHandler.HandleExecuteQuery(&pgproto3.Execute{MaxRows: 2}, preparedStatement)
-		testNoError(t, err)
-		testMessageTypes(t, messages, []pgproto3.Message{
 			&pgproto3.DataRow{},
 			&pgproto3.DataRow{},
-			&pgproto3.PortalSuspended{},
-		})
-
-		messages, err = queryHandler.HandleExecuteQuery(&pgproto3.Execute{MaxRows: 2}, preparedStatement)
-		testNoError(t, err)
-		testMessageTypes(t, messages, []pgproto3.Message{
 			&pgproto3.DataRow{},
 			&pgproto3.CommandComplete{},
 		})
-		if string(messages[0].(*pgproto3.DataRow).Values[0]) != "5" {
-			t.Errorf("Expected the last row to be 5, got %s", string(messages[0].(*pgproto3.DataRow).Values[0]))
-		}
 	})
+}
 
-	t.Run("Returns all rows and CommandComplete when MaxRows is 0", func(t *testing.T) {
-		parseMessage := &pgproto3.Parse{Query: "SELECT i FROM (VALUES (1), (2), (3)) AS t(i)"}
+func TestHandleBindQueryResetsRows(t *testing.T) {
+	createTestTables(t)
+	queryHandler := initQueryHandler()
+	defer queryHandler.duckdb.Close()
+
+	t.Run("Re-binding a statement produces fresh results instead of reusing consumed rows", func(t *testing.T) {
+		parseMessage := &pgproto3.Parse{Query: "SELECT i FROM (VALUES (1), (2)) AS t(i)"}
 		_, preparedStatement, err := queryHandler.HandleParseQuery(parseMessage)
 		testNoError(t, err)
 		_, preparedStatement, err = queryHandler.HandleBindQuery(&pgproto3.Bind{}, preparedStatement)
 		testNoError(t, err)
-
 		messages, err := queryHandler.HandleExecuteQuery(&pgproto3.Execute{}, preparedStatement)
 		testNoError(t, err)
 		testMessageTypes(t, messages, []pgproto3.Message{
 			&pgproto3.DataRow{},
 			&pgproto3.DataRow{},
+			&pgproto3.CommandComplete{},
+		})
+
+		// Second Bind on the same statement: must not resume the consumed rows.
+		_, preparedStatement, err = queryHandler.HandleBindQuery(&pgproto3.Bind{}, preparedStatement)
+		testNoError(t, err)
+		messages, err = queryHandler.HandleExecuteQuery(&pgproto3.Execute{}, preparedStatement)
+		testNoError(t, err)
+		testMessageTypes(t, messages, []pgproto3.Message{
+			&pgproto3.DataRow{},
 			&pgproto3.DataRow{},
 			&pgproto3.CommandComplete{},
 		})
+	})
+}
+
+func TestHandleSimpleQueryWithMaxResultMb(t *testing.T) {
+	createTestTables(t)
+	queryHandler := initQueryHandler()
+	defer queryHandler.duckdb.Close()
+
+	originalMaxResultMb := queryHandler.config.MaxResultMb
+	queryHandler.config.MaxResultMb = 1
+	defer func() { queryHandler.config.MaxResultMb = originalMaxResultMb }()
+
+	t.Run("Applies one shared budget across the statements of a multi-statement query", func(t *testing.T) {
+		// Each statement is ~0.7MB (under the 1MB cap alone); together they exceed
+		// it. All statements accumulate into one buffer, so the budget must too.
+		_, err := queryHandler.HandleSimpleQuery("SELECT repeat('x', 700000); SELECT repeat('y', 700000)")
+		if err == nil {
+			t.Fatalf("Expected an error for combined statement results exceeding the byte cap")
+		}
+		if !strings.Contains(err.Error(), "result exceeded the 1 MB limit") {
+			t.Errorf("Expected a result-size error, got: %v", err)
+		}
 	})
 }
 

--- a/src/query_handler_test.go
+++ b/src/query_handler_test.go
@@ -1732,3 +1732,108 @@ func testResponseByQuery(t *testing.T, queryHandler *QueryHandler, responseByQue
 		})
 	}
 }
+
+func TestHandleExecuteQueryWithMaxRows(t *testing.T) {
+	createTestTables(t)
+	queryHandler := initQueryHandler()
+	defer queryHandler.duckdb.Close()
+
+	t.Run("Suspends the portal at Execute.MaxRows and resumes until completion", func(t *testing.T) {
+		parseMessage := &pgproto3.Parse{Query: "SELECT i FROM (VALUES (1), (2), (3), (4), (5)) AS t(i)"}
+		_, preparedStatement, err := queryHandler.HandleParseQuery(parseMessage)
+		testNoError(t, err)
+		_, preparedStatement, err = queryHandler.HandleBindQuery(&pgproto3.Bind{}, preparedStatement)
+		testNoError(t, err)
+		_, preparedStatement, err = queryHandler.HandleDescribeQuery(&pgproto3.Describe{ObjectType: 'P'}, preparedStatement)
+		testNoError(t, err)
+
+		messages, err := queryHandler.HandleExecuteQuery(&pgproto3.Execute{MaxRows: 2}, preparedStatement)
+		testNoError(t, err)
+		testMessageTypes(t, messages, []pgproto3.Message{
+			&pgproto3.DataRow{},
+			&pgproto3.DataRow{},
+			&pgproto3.PortalSuspended{},
+		})
+		if preparedStatement.Rows == nil {
+			t.Errorf("Expected the suspended portal to keep its rows open")
+		}
+
+		messages, err = queryHandler.HandleExecuteQuery(&pgproto3.Execute{MaxRows: 2}, preparedStatement)
+		testNoError(t, err)
+		testMessageTypes(t, messages, []pgproto3.Message{
+			&pgproto3.DataRow{},
+			&pgproto3.DataRow{},
+			&pgproto3.PortalSuspended{},
+		})
+
+		messages, err = queryHandler.HandleExecuteQuery(&pgproto3.Execute{MaxRows: 2}, preparedStatement)
+		testNoError(t, err)
+		testMessageTypes(t, messages, []pgproto3.Message{
+			&pgproto3.DataRow{},
+			&pgproto3.CommandComplete{},
+		})
+		if string(messages[0].(*pgproto3.DataRow).Values[0]) != "5" {
+			t.Errorf("Expected the last row to be 5, got %s", string(messages[0].(*pgproto3.DataRow).Values[0]))
+		}
+	})
+
+	t.Run("Returns all rows and CommandComplete when MaxRows is 0", func(t *testing.T) {
+		parseMessage := &pgproto3.Parse{Query: "SELECT i FROM (VALUES (1), (2), (3)) AS t(i)"}
+		_, preparedStatement, err := queryHandler.HandleParseQuery(parseMessage)
+		testNoError(t, err)
+		_, preparedStatement, err = queryHandler.HandleBindQuery(&pgproto3.Bind{}, preparedStatement)
+		testNoError(t, err)
+
+		messages, err := queryHandler.HandleExecuteQuery(&pgproto3.Execute{}, preparedStatement)
+		testNoError(t, err)
+		testMessageTypes(t, messages, []pgproto3.Message{
+			&pgproto3.DataRow{},
+			&pgproto3.DataRow{},
+			&pgproto3.DataRow{},
+			&pgproto3.CommandComplete{},
+		})
+	})
+}
+
+func TestHandleExecuteQueryWithMaxResultMb(t *testing.T) {
+	createTestTables(t)
+	queryHandler := initQueryHandler()
+	defer queryHandler.duckdb.Close()
+
+	originalMaxResultMb := queryHandler.config.MaxResultMb
+	queryHandler.config.MaxResultMb = 1
+	defer func() { queryHandler.config.MaxResultMb = originalMaxResultMb }()
+
+	t.Run("Fails a query whose result exceeds the byte cap", func(t *testing.T) {
+		parseMessage := &pgproto3.Parse{Query: "SELECT repeat('x', 500000) AS v FROM (VALUES (1), (2), (3)) AS t(i)"}
+		_, preparedStatement, err := queryHandler.HandleParseQuery(parseMessage)
+		testNoError(t, err)
+		_, preparedStatement, err = queryHandler.HandleBindQuery(&pgproto3.Bind{}, preparedStatement)
+		testNoError(t, err)
+
+		_, err = queryHandler.HandleExecuteQuery(&pgproto3.Execute{}, preparedStatement)
+		if err == nil {
+			t.Fatalf("Expected an error for a result exceeding the byte cap")
+		}
+		if !strings.Contains(err.Error(), "result exceeded the 1 MB limit") {
+			t.Errorf("Expected a result-size error, got: %v", err)
+		}
+	})
+
+	t.Run("Allows a query whose result stays under the byte cap", func(t *testing.T) {
+		parseMessage := &pgproto3.Parse{Query: "SELECT repeat('x', 1000) AS v FROM (VALUES (1), (2), (3)) AS t(i)"}
+		_, preparedStatement, err := queryHandler.HandleParseQuery(parseMessage)
+		testNoError(t, err)
+		_, preparedStatement, err = queryHandler.HandleBindQuery(&pgproto3.Bind{}, preparedStatement)
+		testNoError(t, err)
+
+		messages, err := queryHandler.HandleExecuteQuery(&pgproto3.Execute{}, preparedStatement)
+		testNoError(t, err)
+		testMessageTypes(t, messages, []pgproto3.Message{
+			&pgproto3.DataRow{},
+			&pgproto3.DataRow{},
+			&pgproto3.DataRow{},
+			&pgproto3.CommandComplete{},
+		})
+	})
+}


### PR DESCRIPTION
## Problem

Query results are fully materialized in memory before being written to the connection (`rowsToDataMessages` appends every `DataRow` to one slice) with no bound: one unbounded `SELECT` of a table with megabyte-sized values pushes the process past its container memory limit → kernel OOM kill → outage for every connected client.

## Reproduction (proof of mechanism)

300MB table (3000 rows × ~100KB text), server in a **1GiB cgroup** (`memory_limit=640MB`, 4 threads):

| Query | Reads | Returns | Result |
|---|---|---|---|
| `SELECT sum(length(fat_col))` | all 300MB | 1 row | ✅ healthy |
| `SELECT fat_col` (no LIMIT) | all 300MB | 300MB | ❌ **OOMKilled, exit 137** |

Identical scan; only the returned volume differs — the kill lives in the result buffering.

## Fix

**`--max-result-mb` / `BEMIDB_MAX_RESULT_MB`** (0 = disabled, default): a byte budget on the buffered result — payload bytes **plus estimated per-row/per-cell heap overhead** — shared across **all statements** of a simple-protocol query. Exceeding it fails the query with an actionable error. Negative values fail fast at startup.

**Execute.MaxRows remains deliberately ignored** (a code comment documents why): honoring it requires portal suspension that survives `Sync`, which the one-exchange-per-Parse connection loop can't support — an earlier revision emitted `PortalSuspended` and would have dropped cursor-mode clients (pgjdbc `fetchSize`) on resume, a regression caught in review. Clients keep the pre-existing behavior (full result, client-side truncation), bounded server-side by the byte cap. Cross-Sync portal support is future work.

Also fixed: `Bind` closes/resets prior rows (a new portal can't resume a previous one's results); `Close` is answered with `CloseComplete` and respects the post-error discard rule; `Sync` releases rows leaked by Describe-without-Execute; the test harness no longer destroys `-test.*` flags via its init-time `os.Args` rewrite (previously `-run` never filtered and the first test's pre-existing panic aborted the entire suite, masking all other tests).

## Verification

- Unit tests: byte cap over/under (extended protocol), one-budget-across-statements (simple protocol), Bind reset, and a pin on the deliberate MaxRows-ignoring behavior (full result + `CommandComplete`, never `PortalSuspended`).
- Full suite: `go test -skip '^TestHandleQuery$' .` → `ok` (that test's failure + panic are pre-existing on `pixxel`).
- Live harness on this revision (`BEMIDB_MAX_RESULT_MB=64`): the killer query returns `ERROR: result exceeded the 64 MB limit ...` with the server healthy (`OOMKilled: false`); full-table aggregates, `LIMIT` queries, and under-cap multi-statement queries unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)