### PR TITLE
feat: add JSON array/object expansion functions

### DIFF
--- a/src/parser_a_expr.go
+++ b/src/parser_a_expr.go
@@ -30,8 +30,8 @@ func (parser *ParserAExpr) ConvertedRightAnyToIn(node *pgQuery.Node) *pgQuery.No
 		return node
 	}
 
-	if aExpr.Rexpr.GetAConst() == nil {
-		// NOTE: ... = ANY() on non-constants is not fully supported yet
+	if aExpr.Rexpr.GetAConst() == nil || aExpr.Rexpr.GetAConst().GetSval() == nil {
+		// NOTE: ... = ANY() on non-constants and non-string constants is not fully supported yet
 		return parser.utils.MakeNullNode()
 	}
 

--- a/src/parser_function.go
+++ b/src/parser_function.go
@@ -23,7 +23,8 @@ func (parser *ParserFunction) FirstArgumentToString(functionCall *pgQuery.FuncCa
 	if len(functionCall.Args) < 1 {
 		return ""
 	}
-	return functionCall.Args[0].GetAConst().GetSval().Sval
+	// Nil-safe getter chain: returns "" for non-constant and non-string-constant arguments
+	return functionCall.Args[0].GetAConst().GetSval().GetSval()
 }
 
 // n from (FUNCTION()).n
@@ -130,11 +131,12 @@ func (parser *ParserFunction) RemapToFunction(functionCall *pgQuery.FuncCall, na
 }
 
 func (parser *ParserFunction) constStringValue(node *pgQuery.Node) string {
+	// Nil-safe getter chains: return "" for non-string constants (e.g. integers) instead of panicking
 	if node.GetAConst() != nil {
-		return node.GetAConst().GetSval().Sval
+		return node.GetAConst().GetSval().GetSval()
 	}
 	if typeCast := node.GetTypeCast(); typeCast != nil && typeCast.Arg.GetAConst() != nil {
-		return typeCast.Arg.GetAConst().GetSval().Sval
+		return typeCast.Arg.GetAConst().GetSval().GetSval()
 	}
 	return ""
 }
@@ -288,9 +290,15 @@ func (parser *ParserFunction) RemapJsonbExtractPathText(functionCall *pgQuery.Fu
 	}
 
 	pathArgs := functionCall.Args[1:]
-	// jsonb_extract_path_text(json, VARIADIC ARRAY['a', 'b'])
-	if arrayExpr := functionCall.Args[1].GetAArrayExpr(); functionCall.FuncVariadic && arrayExpr != nil {
-		pathArgs = arrayExpr.Elements
+	// jsonb_extract_path_text(json, VARIADIC ARRAY['a', 'b']) with an optional ::text[] cast around the ARRAY
+	if functionCall.FuncVariadic {
+		arrayNode := functionCall.Args[1]
+		if typeCast := arrayNode.GetTypeCast(); typeCast != nil {
+			arrayNode = typeCast.Arg
+		}
+		if arrayExpr := arrayNode.GetAArrayExpr(); arrayExpr != nil {
+			pathArgs = arrayExpr.Elements
+		}
 	}
 
 	pathParts := []string{"$"}

--- a/src/parser_function.go
+++ b/src/parser_function.go
@@ -258,9 +258,7 @@ func (parser *ParserFunction) RemapToDate(functionCall *pgQuery.FuncCall) {
 }
 
 // to_timestamp('2024-01-15 10:30', 'YYYY-MM-DD HH24:MI')
-//
-//	-> strptime('2024-01-15 10:30', '%Y-%m-%d %H:%M')
-//
+//   -> strptime('2024-01-15 10:30', '%Y-%m-%d %H:%M')
 // Note: PG's to_timestamp(epoch_seconds) is a 1-arg form that DuckDB already
 // supports natively, so we only remap the 2-arg form here.
 func (parser *ParserFunction) RemapToTimestampFormat(functionCall *pgQuery.FuncCall) {
@@ -282,9 +280,7 @@ func (parser *ParserFunction) RemapToTimestampFormat(functionCall *pgQuery.FuncC
 }
 
 // jsonb_extract_path_text(json, 'a', 'b', 'c')
-//
-//	-> json_extract_string(json, '$.a.b.c')
-//
+//   -> json_extract_string(json, '$.a.b.c')
 // Converts path elements (plain args or a VARIADIC ARRAY[...] arg) into a JSONPath string.
 func (parser *ParserFunction) RemapJsonbExtractPathText(functionCall *pgQuery.FuncCall) {
 	if len(functionCall.Args) < 2 {

--- a/src/parser_function.go
+++ b/src/parser_function.go
@@ -258,7 +258,9 @@ func (parser *ParserFunction) RemapToDate(functionCall *pgQuery.FuncCall) {
 }
 
 // to_timestamp('2024-01-15 10:30', 'YYYY-MM-DD HH24:MI')
-//   -> strptime('2024-01-15 10:30', '%Y-%m-%d %H:%M')
+//
+//	-> strptime('2024-01-15 10:30', '%Y-%m-%d %H:%M')
+//
 // Note: PG's to_timestamp(epoch_seconds) is a 1-arg form that DuckDB already
 // supports natively, so we only remap the 2-arg form here.
 func (parser *ParserFunction) RemapToTimestampFormat(functionCall *pgQuery.FuncCall) {
@@ -280,15 +282,23 @@ func (parser *ParserFunction) RemapToTimestampFormat(functionCall *pgQuery.FuncC
 }
 
 // jsonb_extract_path_text(json, 'a', 'b', 'c')
-//   -> json_extract_string(json, '$.a.b.c')
-// Converts variadic path elements into a JSONPath string.
+//
+//	-> json_extract_string(json, '$.a.b.c')
+//
+// Converts path elements (plain args or a VARIADIC ARRAY[...] arg) into a JSONPath string.
 func (parser *ParserFunction) RemapJsonbExtractPathText(functionCall *pgQuery.FuncCall) {
 	if len(functionCall.Args) < 2 {
 		return
 	}
 
+	pathArgs := functionCall.Args[1:]
+	// jsonb_extract_path_text(json, VARIADIC ARRAY['a', 'b'])
+	if arrayExpr := functionCall.Args[1].GetAArrayExpr(); functionCall.FuncVariadic && arrayExpr != nil {
+		pathArgs = arrayExpr.Elements
+	}
+
 	pathParts := []string{"$"}
-	for _, arg := range functionCall.Args[1:] {
+	for _, arg := range pathArgs {
 		part := parser.constStringValue(arg)
 		if part == "" {
 			return
@@ -298,6 +308,7 @@ func (parser *ParserFunction) RemapJsonbExtractPathText(functionCall *pgQuery.Fu
 	jsonPath := strings.Join(pathParts, ".")
 
 	functionCall.Funcname = []*pgQuery.Node{pgQuery.MakeStrNode("json_extract_string")}
+	functionCall.FuncVariadic = false
 	functionCall.Args = []*pgQuery.Node{
 		functionCall.Args[0],
 		pgQuery.MakeAConstStrNode(jsonPath, 0),

--- a/src/parser_type_cast.go
+++ b/src/parser_type_cast.go
@@ -140,8 +140,8 @@ func (parser *ParserTypeCast) MakeSubselectOidBySchemaTableArg(argumentNode *pgQ
 		),
 	)
 
-	if argumentNode.GetAConst() == nil {
-		// NOTE: ::regclass::oid on non-constants is not fully supported yet
+	if argumentNode.GetAConst() == nil || argumentNode.GetAConst().GetSval() == nil {
+		// NOTE: ::regclass::oid on non-constants and non-string constants (e.g. 1::regclass) is not fully supported yet
 		return parser.utils.MakeNullNode()
 	}
 

--- a/src/parser_type_cast.go
+++ b/src/parser_type_cast.go
@@ -65,7 +65,8 @@ func (parser *ParserTypeCast) RemovedDefaultCollateClause(node *pgQuery.Node) *p
 }
 
 func (parser *ParserTypeCast) ArgStringValue(typeCast *pgQuery.TypeCast) string {
-	return typeCast.Arg.GetAConst().GetSval().Sval
+	// Nil-safe getter chain: returns "" for non-constant and non-string-constant arguments
+	return typeCast.Arg.GetAConst().GetSval().GetSval()
 }
 
 // pg_catalog.[type] -> [type]
@@ -83,7 +84,12 @@ func (parser *ParserTypeCast) SetTypeName(typeCast *pgQuery.TypeCast, name strin
 	typeCast.TypeName.Names = []*pgQuery.Node{pgQuery.MakeStrNode(name)}
 }
 
+// Returns nil if the argument is not a string constant (e.g. a column reference or 123::text[])
 func (parser *ParserTypeCast) MakeListValueFromArray(node *pgQuery.Node) *pgQuery.Node {
+	if node.GetAConst() == nil || node.GetAConst().GetSval() == nil {
+		return nil
+	}
+
 	arrayStr := node.GetAConst().GetSval().Sval
 	arrayStr = strings.Trim(arrayStr, "{}")
 	elements := strings.Split(arrayStr, ",")

--- a/src/query_handler_test.go
+++ b/src/query_handler_test.go
@@ -1658,6 +1658,7 @@ func testNoError(t *testing.T, err error) {
 func testMessageTypes(t *testing.T, messages []pgproto3.Message, expectedTypes []pgproto3.Message) {
 	if len(messages) != len(expectedTypes) {
 		t.Errorf("Expected %v messages, got %v", len(expectedTypes), len(messages))
+		return // Fail instead of panicking with index out of range below (which aborts the whole test suite)
 	}
 
 	for i, expectedType := range expectedTypes {
@@ -1668,10 +1669,15 @@ func testMessageTypes(t *testing.T, messages []pgproto3.Message, expectedTypes [
 }
 
 func testRowDescription(t *testing.T, rowDescriptionMessage pgproto3.Message, expectedColumnNames []string, expectedColumnTypes []string) {
-	rowDescription := rowDescriptionMessage.(*pgproto3.RowDescription)
+	rowDescription, ok := rowDescriptionMessage.(*pgproto3.RowDescription)
+	if !ok {
+		t.Errorf("Expected a RowDescription message, got %T", rowDescriptionMessage)
+		return
+	}
 
 	if len(rowDescription.Fields) != len(expectedColumnNames) {
 		t.Errorf("Expected %v row description fields, got %v", len(expectedColumnNames), len(rowDescription.Fields))
+		return // Fail instead of panicking with index out of range below (which aborts the whole test suite)
 	}
 
 	for i, expectedColumnName := range expectedColumnNames {
@@ -1688,10 +1694,15 @@ func testRowDescription(t *testing.T, rowDescriptionMessage pgproto3.Message, ex
 }
 
 func testDataRowValues(t *testing.T, dataRowMessage pgproto3.Message, expectedValues []string) {
-	dataRow := dataRowMessage.(*pgproto3.DataRow)
+	dataRow, ok := dataRowMessage.(*pgproto3.DataRow)
+	if !ok {
+		t.Errorf("Expected a DataRow message, got %T", dataRowMessage)
+		return
+	}
 
 	if len(dataRow.Values) != len(expectedValues) {
 		t.Errorf("Expected %v data row values, got %v", len(expectedValues), len(dataRow.Values))
+		return // Fail instead of panicking with index out of range below (which aborts the whole test suite)
 	}
 
 	for i, expectedValue := range expectedValues {
@@ -1714,6 +1725,9 @@ func testResponseByQuery(t *testing.T, queryHandler *QueryHandler, responseByQue
 			messages, err := queryHandler.HandleSimpleQuery(query)
 
 			testNoError(t, err)
+			if len(messages) == 0 {
+				return // The error above already failed the test; avoid panicking on messages[0] (which aborts the whole test suite)
+			}
 			testRowDescription(t, messages[0], responses["description"], responses["types"])
 
 			if len(responses["values"]) > 0 {
@@ -1722,7 +1736,9 @@ func testResponseByQuery(t *testing.T, queryHandler *QueryHandler, responseByQue
 					&pgproto3.DataRow{},
 					&pgproto3.CommandComplete{},
 				})
-				testDataRowValues(t, messages[1], responses["values"])
+				if len(messages) == 3 {
+					testDataRowValues(t, messages[1], responses["values"])
+				}
 			} else {
 				testMessageTypes(t, messages, []pgproto3.Message{
 					&pgproto3.RowDescription{},

--- a/src/query_handler_test.go
+++ b/src/query_handler_test.go
@@ -172,6 +172,76 @@ func TestHandleQuery(t *testing.T) {
 		})
 	})
 
+	t.Run("JSON functions", func(t *testing.T) {
+		testResponseByQuery(t, queryHandler, map[string]map[string][]string{
+			"SELECT json_array_elements('[{\"a\":1},{\"a\":2}]') LIMIT 1": {
+				"description": {"json_array_elements"},
+				"types":       {Uint32ToString(pgtype.TextOID)},
+				"values":      {"{\"a\":1}"},
+			},
+			"SELECT jsonb_array_elements(NULL) AS element": {
+				"description": {"element"},
+				"types":       {Uint32ToString(pgtype.TextOID)},
+				"values":      {},
+			},
+			"SELECT COUNT(*) AS count FROM jsonb_array_elements('[1, 2, 3]')": {
+				"description": {"count"},
+				"types":       {Uint32ToString(pgtype.Int8OID)},
+				"values":      {"3"},
+			},
+			"SELECT value FROM pg_catalog.json_array_elements('[\"x\"]')": {
+				"description": {"value"},
+				"types":       {Uint32ToString(pgtype.TextOID)},
+				"values":      {"\"x\""},
+			},
+			"SELECT value FROM json_array_elements_text('[\"first\", \"second\"]') LIMIT 1": {
+				"description": {"value"},
+				"types":       {Uint32ToString(pgtype.TextOID)},
+				"values":      {"first"},
+			},
+			"SELECT key, value FROM json_each('{\"a\": 1, \"b\": \"x\"}') WHERE key = 'b'": {
+				"description": {"key", "value"},
+				"types":       {Uint32ToString(pgtype.TextOID), Uint32ToString(pgtype.TextOID)},
+				"values":      {"b", "\"x\""},
+			},
+			"SELECT key, value FROM jsonb_each_text('{\"a\": 1, \"b\": \"x\"}') WHERE key = 'b'": {
+				"description": {"key", "value"},
+				"types":       {Uint32ToString(pgtype.TextOID), Uint32ToString(pgtype.TextOID)},
+				"values":      {"b", "x"},
+			},
+			"SELECT json_object_keys(json_column) AS key FROM public.test_table WHERE json_column IS NOT NULL": {
+				"description": {"key"},
+				"types":       {Uint32ToString(pgtype.TextOID)},
+				"values":      {"key"},
+			},
+			"SELECT '{\"a\": {\"b\": 2}}'::jsonb->'a'->>'b' AS value": {
+				"description": {"value"},
+				"types":       {Uint32ToString(pgtype.TextOID)},
+				"values":      {"2"},
+			},
+			"SELECT t.id, json_extract_string(c.value, '$.aoi') AS aoi FROM (VALUES (1, '{\"components\": [{\"aoi\": \"area-77\"}]}')) t (id, spec), jsonb_array_elements(t.spec->'components') c": {
+				"description": {"id", "aoi"},
+				"types":       {Uint32ToString(pgtype.Int4OID), Uint32ToString(pgtype.TextOID)},
+				"values":      {"1", "area-77"},
+			},
+			"SELECT e.key, e.value FROM public.test_table tt, json_each(tt.json_column) e WHERE tt.json_column IS NOT NULL": {
+				"description": {"key", "value"},
+				"types":       {Uint32ToString(pgtype.TextOID), Uint32ToString(pgtype.TextOID)},
+				"values":      {"key", "\"value\""},
+			},
+			"SELECT j.job_id, c.value ->> 'type' AS type FROM (VALUES (1, '{\"components\": [{\"type\": \"aoi\"}]}')) j (job_id, spec) CROSS JOIN LATERAL jsonb_array_elements(j.spec::jsonb -> 'components') c": {
+				"description": {"job_id", "type"},
+				"types":       {Uint32ToString(pgtype.Int4OID), Uint32ToString(pgtype.TextOID)},
+				"values":      {"1", "aoi"},
+			},
+			"SELECT j.job_id, c.value FROM (VALUES (2, '{\"components\": []}')) j (job_id, spec) LEFT JOIN LATERAL jsonb_array_elements(j.spec::jsonb -> 'components') c ON true": {
+				"description": {"job_id", "value"},
+				"types":       {Uint32ToString(pgtype.Int4OID), Uint32ToString(pgtype.TextOID)},
+				"values":      {"2", ""},
+			},
+		})
+	})
+
 	t.Run("PG system tables", func(t *testing.T) {
 		testResponseByQuery(t, queryHandler, map[string]map[string][]string{
 			"SELECT oid, typname AS typename FROM pg_type WHERE typname='geometry' OR typname='geography'": {

--- a/src/query_handler_test.go
+++ b/src/query_handler_test.go
@@ -149,6 +149,21 @@ func TestHandleQuery(t *testing.T) {
 				"types":       {Uint32ToString(pgtype.TextOID)},
 				"values":      {"value"},
 			},
+			"SELECT jsonb_extract_path_text(json_column, VARIADIC ARRAY['key']::text[]) AS jsonb_extract_path_text FROM test_table LIMIT 1": {
+				"description": {"jsonb_extract_path_text"},
+				"types":       {Uint32ToString(pgtype.TextOID)},
+				"values":      {"value"},
+			},
+			"SELECT bemidb_last_synced_at(123) AS last_synced_at": {
+				"description": {"last_synced_at"},
+				"types":       {Uint32ToString(pgtype.TimestamptzOID)},
+				"values":      {""},
+			},
+			"SELECT 1 AS value WHERE 1 = ANY(123)": {
+				"description": {"value"},
+				"types":       {Uint32ToString(pgtype.Int4OID)},
+				"values":      {},
+			},
 			"SELECT encode(sha256('foo'), 'hex'::text) AS encode": {
 				"description": {"encode"},
 				"types":       {Uint32ToString(pgtype.TextOID)},
@@ -238,6 +253,16 @@ func TestHandleQuery(t *testing.T) {
 				"description": {"job_id", "value"},
 				"types":       {Uint32ToString(pgtype.Int4OID), Uint32ToString(pgtype.TextOID)},
 				"values":      {"2", ""},
+			},
+			"SELECT t1.id AS id, c.value AS value FROM (VALUES (1)) t1 (id), (VALUES (2)) t2 (y) JOIN jsonb_array_elements('[5]') c ON true": {
+				"description": {"id", "value"},
+				"types":       {Uint32ToString(pgtype.Int4OID), Uint32ToString(pgtype.TextOID)},
+				"values":      {"1", "5"},
+			},
+			"SELECT COUNT(*) AS count FROM (VALUES (1)) v (x), public.test_table t1 JOIN public.test_table t2 ON t2.id = t1.id": {
+				"description": {"count"},
+				"types":       {Uint32ToString(pgtype.Int8OID)},
+				"values":      {"2"},
 			},
 		})
 	})
@@ -1727,8 +1752,9 @@ func testNoError(t *testing.T, err error) {
 
 func testMessageTypes(t *testing.T, messages []pgproto3.Message, expectedTypes []pgproto3.Message) {
 	if len(messages) != len(expectedTypes) {
-		t.Errorf("Expected %v messages, got %v", len(expectedTypes), len(messages))
-		return // Fail instead of panicking with index out of range below (which aborts the whole test suite)
+		// Fatal instead of panicking with index out of range below (which aborts the whole test suite).
+		// This also protects callers that index into messages[N] right after this check.
+		t.Fatalf("Expected %v messages, got %v", len(expectedTypes), len(messages))
 	}
 
 	for i, expectedType := range expectedTypes {
@@ -1806,9 +1832,7 @@ func testResponseByQuery(t *testing.T, queryHandler *QueryHandler, responseByQue
 					&pgproto3.DataRow{},
 					&pgproto3.CommandComplete{},
 				})
-				if len(messages) == 3 {
-					testDataRowValues(t, messages[1], responses["values"])
-				}
+				testDataRowValues(t, messages[1], responses["values"])
 			} else {
 				testMessageTypes(t, messages, []pgproto3.Message{
 					&pgproto3.RowDescription{},

--- a/src/query_handler_test.go
+++ b/src/query_handler_test.go
@@ -224,6 +224,26 @@ func TestHandleQuery(t *testing.T) {
 				"types":       {Uint32ToString(pgtype.TextOID), Uint32ToString(pgtype.TextOID)},
 				"values":      {"b", "x"},
 			},
+			"SELECT key, value FROM jsonb_each('{\"a\": 1, \"b\": \"x\"}') WHERE key = 'b'": {
+				"description": {"key", "value"},
+				"types":       {Uint32ToString(pgtype.TextOID), Uint32ToString(pgtype.TextOID)},
+				"values":      {"b", "\"x\""},
+			},
+			"SELECT key, value FROM json_each_text('{\"a\": 1, \"b\": \"x\"}') WHERE key = 'b'": {
+				"description": {"key", "value"},
+				"types":       {Uint32ToString(pgtype.TextOID), Uint32ToString(pgtype.TextOID)},
+				"values":      {"b", "x"},
+			},
+			"SELECT json_object_keys FROM json_object_keys('{\"k1\": 1, \"k2\": 2}') WHERE json_object_keys = 'k2'": {
+				"description": {"json_object_keys"},
+				"types":       {Uint32ToString(pgtype.TextOID)},
+				"values":      {"k2"},
+			},
+			"SELECT jsonb_object_keys FROM jsonb_object_keys('{\"k1\": 1, \"k2\": 2}') WHERE jsonb_object_keys = 'k1'": {
+				"description": {"jsonb_object_keys"},
+				"types":       {Uint32ToString(pgtype.TextOID)},
+				"values":      {"k1"},
+			},
 			"SELECT json_object_keys(json_column) AS key FROM public.test_table WHERE json_column IS NOT NULL": {
 				"description": {"key"},
 				"types":       {Uint32ToString(pgtype.TextOID)},

--- a/src/query_remapper.go
+++ b/src/query_remapper.go
@@ -204,7 +204,8 @@ func (remapper *QueryRemapper) remapSelectStatement(selectStatement *pgQuery.Sel
 			} else if fromNode.GetRangeFunction() != nil {
 				// FROM PG_FUNCTION()
 				remapper.traceTreeTraversal("FROM function()", indentLevel)
-				remapper.remapperTable.RemapTableFunctionCall(fromNode.GetRangeFunction()) // recursion
+				remapper.remapperTable.RemapTableFunctionCall(fromNode.GetRangeFunction())  // recursion
+				remapper.remapTableFunctionArgs(fromNode.GetRangeFunction(), indentLevel+1) // recursion
 			}
 		}
 	}
@@ -241,6 +242,11 @@ func (remapper *QueryRemapper) remapJoinExpressions(selectStatement *pgQuery.Sel
 	} else if leftJoinNode.GetRangeSubselect() != nil {
 		leftSelectStatement := leftJoinNode.GetRangeSubselect().Subquery.GetSelectStmt()
 		remapper.remapSelectStatement(leftSelectStatement, indentLevel+1) // parent-recursion
+	} else if leftJoinNode.GetRangeFunction() != nil {
+		// JOIN [LATERAL] FUNCTION() left
+		remapper.traceTreeTraversal("FUNCTION() left", indentLevel+1)
+		remapper.remapperTable.RemapTableFunctionCall(leftJoinNode.GetRangeFunction())
+		remapper.remapTableFunctionArgs(leftJoinNode.GetRangeFunction(), indentLevel+1) // recursion
 	}
 	node.GetJoinExpr().Larg = leftJoinNode
 
@@ -255,6 +261,11 @@ func (remapper *QueryRemapper) remapJoinExpressions(selectStatement *pgQuery.Sel
 	} else if rightJoinNode.GetRangeSubselect() != nil {
 		rightSelectStatement := rightJoinNode.GetRangeSubselect().Subquery.GetSelectStmt()
 		remapper.remapSelectStatement(rightSelectStatement, indentLevel+1) // parent-recursion
+	} else if rightJoinNode.GetRangeFunction() != nil {
+		// JOIN [LATERAL] FUNCTION() right
+		remapper.traceTreeTraversal("FUNCTION() right", indentLevel+1)
+		remapper.remapperTable.RemapTableFunctionCall(rightJoinNode.GetRangeFunction())
+		remapper.remapTableFunctionArgs(rightJoinNode.GetRangeFunction(), indentLevel+1) // recursion
 	}
 	node.GetJoinExpr().Rarg = rightJoinNode
 
@@ -379,6 +390,24 @@ func (remapper *QueryRemapper) remappedExpressions(node *pgQuery.Node, indentLev
 	}
 
 	return remapper.remapperExpression.RemappedExpression(node)
+}
+
+// FROM FUNCTION(args) -> remap expressions in args (e.g. '...'::jsonb casts, schema.table.column references)
+func (remapper *QueryRemapper) remapTableFunctionArgs(rangeFunction *pgQuery.RangeFunction, indentLevel int) {
+	for _, funcNode := range rangeFunction.Functions {
+		for _, funcItemNode := range funcNode.GetList().Items {
+			functionCall := funcItemNode.GetFuncCall()
+			if functionCall == nil {
+				continue
+			}
+
+			for i, arg := range functionCall.Args {
+				if arg != nil {
+					functionCall.Args[i] = remapper.remappedExpressions(arg, indentLevel) // recursion
+				}
+			}
+		}
+	}
 }
 
 // CASE ...

--- a/src/query_remapper.go
+++ b/src/query_remapper.go
@@ -204,8 +204,8 @@ func (remapper *QueryRemapper) remapSelectStatement(selectStatement *pgQuery.Sel
 			} else if fromNode.GetRangeFunction() != nil {
 				// FROM PG_FUNCTION()
 				remapper.traceTreeTraversal("FROM function()", indentLevel)
-				remapper.remapperTable.RemapTableFunctionCall(fromNode.GetRangeFunction())  // recursion
-				remapper.remapTableFunctionArgs(fromNode.GetRangeFunction(), indentLevel+1) // recursion
+				remapper.remapperTable.RemapTableFunctionCall(fromNode.GetRangeFunction()) // recursion
+				remapper.remapTableFunctionArgs(fromNode.GetRangeFunction(), indentLevel+1)
 			}
 		}
 	}

--- a/src/query_remapper.go
+++ b/src/query_remapper.go
@@ -199,8 +199,7 @@ func (remapper *QueryRemapper) remapSelectStatement(selectStatement *pgQuery.Sel
 			} else if fromNode.GetRangeFunction() != nil {
 				// FROM PG_FUNCTION()
 				remapper.traceTreeTraversal("FROM function()", indentLevel)
-				remapper.remapperTable.RemapTableFunctionCall(fromNode.GetRangeFunction()) // recursion
-				remapper.remapTableFunctionArgs(fromNode.GetRangeFunction(), indentLevel+1)
+				remapper.remapTableFunction(fromNode.GetRangeFunction(), indentLevel+1) // recursion
 			} else if fromNode.GetJoinExpr() != nil {
 				// FROM [TABLE] JOIN [TABLE] ON ... (at any position in the FROM list, e.g. FROM a, b JOIN c ON ...)
 				selectStatement.FromClause[i] = remapper.remapJoinExpressions(selectStatement, fromNode, indentLevel+1) // recursion
@@ -243,8 +242,7 @@ func (remapper *QueryRemapper) remapJoinExpressions(selectStatement *pgQuery.Sel
 	} else if leftJoinNode.GetRangeFunction() != nil {
 		// JOIN [LATERAL] FUNCTION() left
 		remapper.traceTreeTraversal("FUNCTION() left", indentLevel+1)
-		remapper.remapperTable.RemapTableFunctionCall(leftJoinNode.GetRangeFunction())
-		remapper.remapTableFunctionArgs(leftJoinNode.GetRangeFunction(), indentLevel+1) // recursion
+		remapper.remapTableFunction(leftJoinNode.GetRangeFunction(), indentLevel+1) // recursion
 	}
 	node.GetJoinExpr().Larg = leftJoinNode
 
@@ -262,8 +260,7 @@ func (remapper *QueryRemapper) remapJoinExpressions(selectStatement *pgQuery.Sel
 	} else if rightJoinNode.GetRangeFunction() != nil {
 		// JOIN [LATERAL] FUNCTION() right
 		remapper.traceTreeTraversal("FUNCTION() right", indentLevel+1)
-		remapper.remapperTable.RemapTableFunctionCall(rightJoinNode.GetRangeFunction())
-		remapper.remapTableFunctionArgs(rightJoinNode.GetRangeFunction(), indentLevel+1) // recursion
+		remapper.remapTableFunction(rightJoinNode.GetRangeFunction(), indentLevel+1) // recursion
 	}
 	node.GetJoinExpr().Rarg = rightJoinNode
 
@@ -390,8 +387,11 @@ func (remapper *QueryRemapper) remappedExpressions(node *pgQuery.Node, indentLev
 	return remapper.remapperExpression.RemappedExpression(node)
 }
 
-// FROM FUNCTION(args) -> remap expressions in args (e.g. '...'::jsonb casts, schema.table.column references)
-func (remapper *QueryRemapper) remapTableFunctionArgs(rangeFunction *pgQuery.RangeFunction, indentLevel int) {
+// FROM/JOIN FUNCTION(args) -> remap the function call itself and the expressions in its args
+// (e.g. '...'::jsonb casts, schema.table.column references)
+func (remapper *QueryRemapper) remapTableFunction(rangeFunction *pgQuery.RangeFunction, indentLevel int) {
+	remapper.remapperTable.RemapTableFunctionCall(rangeFunction)
+
 	for _, functionCall := range remapper.remapperTable.TableFunctionCalls(rangeFunction) {
 		for i, arg := range functionCall.Args {
 			if arg != nil {

--- a/src/query_remapper.go
+++ b/src/query_remapper.go
@@ -163,11 +163,6 @@ func (remapper *QueryRemapper) remapSelectStatement(selectStatement *pgQuery.Sel
 		remapper.remapSelectStatement(rightSelectStatement, indentLevel+1) // self-recursion
 	}
 
-	// JOIN
-	if len(selectStatement.FromClause) > 0 && selectStatement.FromClause[0].GetJoinExpr() != nil {
-		selectStatement.FromClause[0] = remapper.remapJoinExpressions(selectStatement, selectStatement.FromClause[0], indentLevel+1) // recursion
-	}
-
 	// WHERE
 	if selectStatement.WhereClause != nil {
 		remapper.traceTreeTraversal("WHERE statements", indentLevel)
@@ -206,6 +201,9 @@ func (remapper *QueryRemapper) remapSelectStatement(selectStatement *pgQuery.Sel
 				remapper.traceTreeTraversal("FROM function()", indentLevel)
 				remapper.remapperTable.RemapTableFunctionCall(fromNode.GetRangeFunction()) // recursion
 				remapper.remapTableFunctionArgs(fromNode.GetRangeFunction(), indentLevel+1)
+			} else if fromNode.GetJoinExpr() != nil {
+				// FROM [TABLE] JOIN [TABLE] ON ... (at any position in the FROM list, e.g. FROM a, b JOIN c ON ...)
+				selectStatement.FromClause[i] = remapper.remapJoinExpressions(selectStatement, fromNode, indentLevel+1) // recursion
 			}
 		}
 	}
@@ -394,17 +392,10 @@ func (remapper *QueryRemapper) remappedExpressions(node *pgQuery.Node, indentLev
 
 // FROM FUNCTION(args) -> remap expressions in args (e.g. '...'::jsonb casts, schema.table.column references)
 func (remapper *QueryRemapper) remapTableFunctionArgs(rangeFunction *pgQuery.RangeFunction, indentLevel int) {
-	for _, funcNode := range rangeFunction.Functions {
-		for _, funcItemNode := range funcNode.GetList().Items {
-			functionCall := funcItemNode.GetFuncCall()
-			if functionCall == nil {
-				continue
-			}
-
-			for i, arg := range functionCall.Args {
-				if arg != nil {
-					functionCall.Args[i] = remapper.remappedExpressions(arg, indentLevel) // recursion
-				}
+	for _, functionCall := range remapper.remapperTable.TableFunctionCalls(rangeFunction) {
+		for i, arg := range functionCall.Args {
+			if arg != nil {
+				functionCall.Args[i] = remapper.remappedExpressions(arg, indentLevel) // recursion
 			}
 		}
 	}

--- a/src/query_remapper_expression.go
+++ b/src/query_remapper_expression.go
@@ -49,10 +49,17 @@ func (remapper *QueryRemapperExpression) remappedTypeCast(node *pgQuery.Node) *p
 		return node
 	case "text[]":
 		// '{a,b,c}'::text[] -> ARRAY['a', 'b', 'c']
-		return remapper.parserTypeCast.MakeListValueFromArray(typeCast.Arg)
+		if listNode := remapper.parserTypeCast.MakeListValueFromArray(typeCast.Arg); listNode != nil {
+			return listNode
+		}
+		return node
 	case "regproc":
 		// 'schema.function_name'::regproc -> 'function_name'
-		nameParts := strings.Split(remapper.parserTypeCast.ArgStringValue(typeCast), ".")
+		value := remapper.parserTypeCast.ArgStringValue(typeCast)
+		if value == "" {
+			return node
+		}
+		nameParts := strings.Split(value, ".")
 		return pgQuery.MakeAConstStrNode(nameParts[len(nameParts)-1], 0)
 	case "regclass":
 		// 'schema.table'::regclass -> SELECT c.oid FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'schema' AND c.relname = 'table'

--- a/src/query_remapper_function.go
+++ b/src/query_remapper_function.go
@@ -62,8 +62,15 @@ func CreatePgCatalogMacroQueries(config *Config) []string {
 		"CREATE MACRO every(x) AS bool_and(x)",
 		"CREATE MACRO json_typeof(j) AS json_type(j)",
 		"CREATE MACRO jsonb_typeof(j) AS json_type(j)",
-		"CREATE MACRO json_object_keys(j) AS json_keys(j)",
-		"CREATE MACRO jsonb_object_keys(j) AS json_keys(j)",
+		// JSON set-returning functions used in the SELECT list: SELECT json_array_elements(...) FROM ...
+		// js::JSON makes element splitting JSON-aware (DuckDB's plain VARCHAR -> list cast is not)
+		"CREATE MACRO json_array_elements(js) AS unnest(CAST(js::JSON AS JSON[]))",
+		"CREATE MACRO jsonb_array_elements(js) AS unnest(CAST(js::JSON AS JSON[]))",
+		"CREATE MACRO json_array_elements_text(js) AS unnest(CAST(js::JSON AS VARCHAR[]))",
+		"CREATE MACRO jsonb_array_elements_text(js) AS unnest(CAST(js::JSON AS VARCHAR[]))",
+		// One row per key to match Postgres SETOF semantics (previously returned the whole key array in one row)
+		"CREATE MACRO json_object_keys(j) AS unnest(json_keys(j))",
+		"CREATE MACRO jsonb_object_keys(j) AS unnest(json_keys(j))",
 		"CREATE MACRO json_agg(x) AS json_group_array(x)",
 		"CREATE MACRO jsonb_agg(x) AS json_group_array(x)",
 		"CREATE MACRO json_object_agg(k, v) AS json_group_object(k, v)",
@@ -110,6 +117,20 @@ func CreatePgCatalogMacroQueries(config *Config) []string {
 			keyword_category AS catdesc,
 			'can be bare label' AS baredesc
 		FROM duckdb_keywords()`,
+
+		// JSON set-returning functions used in the FROM clause (incl. laterally): FROM table, json_each(table.column)
+		// Same names as the scalar macros above: DuckDB stores scalar and table macros in separate catalog namespaces
+		"CREATE MACRO json_array_elements(js) AS TABLE SELECT unnest(CAST(js::JSON AS JSON[])) AS value",
+		"CREATE MACRO jsonb_array_elements(js) AS TABLE SELECT unnest(CAST(js::JSON AS JSON[])) AS value",
+		"CREATE MACRO json_array_elements_text(js) AS TABLE SELECT unnest(CAST(js::JSON AS VARCHAR[])) AS value",
+		"CREATE MACRO jsonb_array_elements_text(js) AS TABLE SELECT unnest(CAST(js::JSON AS VARCHAR[])) AS value",
+		"CREATE MACRO json_object_keys(js) AS TABLE SELECT unnest(json_keys(js)) AS json_object_keys",
+		"CREATE MACRO jsonb_object_keys(js) AS TABLE SELECT unnest(json_keys(js)) AS jsonb_object_keys",
+		// unnest(..., recursive := true) flattens the map entry STRUCT(key, value) into (key, value) columns
+		"CREATE MACRO json_each(js) AS TABLE SELECT unnest(map_entries(CAST(js::JSON AS MAP(VARCHAR, JSON))), recursive := true)",
+		"CREATE MACRO jsonb_each(js) AS TABLE SELECT unnest(map_entries(CAST(js::JSON AS MAP(VARCHAR, JSON))), recursive := true)",
+		"CREATE MACRO json_each_text(js) AS TABLE SELECT unnest(map_entries(CAST(js::JSON AS MAP(VARCHAR, VARCHAR))), recursive := true)",
+		"CREATE MACRO jsonb_each_text(js) AS TABLE SELECT unnest(map_entries(CAST(js::JSON AS MAP(VARCHAR, VARCHAR))), recursive := true)",
 	}
 	PG_CATALOG_MACRO_FUNCTION_NAMES = extractMacroNames(result)
 	return result

--- a/src/query_remapper_table.go
+++ b/src/query_remapper_table.go
@@ -184,6 +184,10 @@ func (remapper *QueryRemapperTable) RemapTable(node *pgQuery.Node) *pgQuery.Node
 	})
 }
 
+func (remapper *QueryRemapperTable) TableFunctionCalls(rangeFunction *pgQuery.RangeFunction) []*pgQuery.FuncCall {
+	return remapper.parserTable.TableFunctionCalls(rangeFunction)
+}
+
 // FROM FUNCTION()
 func (remapper *QueryRemapperTable) RemapTableFunctionCall(rangeFunction *pgQuery.RangeFunction) {
 	schemaFunction := remapper.parserTable.TopLevelSchemaFunction(rangeFunction)


### PR DESCRIPTION
## Why

DWH request: analysts need to expand JSON arrays into rows to analyze workflow specs in `dexter_public.job` (iterate `components[]`, extract AOI ids, map block linkages). Scalar JSON functions (`json_extract`, `->`, `->>`) already work because DuckDB has them natively, but Postgres' set-returning JSON functions have **no DuckDB equivalent — DuckDB has no `json_each`/`json_tree` in any version**, so upgrading the engine was never an option. This implements them as DuckDB macros, following the existing pg-compat macro pattern.

## What's added

| Function | SELECT-list | FROM clause (incl. lateral) |
|---|---|---|
| `json_array_elements` / `jsonb_array_elements` | ✅ | ✅ |
| `json_array_elements_text` / `jsonb_array_elements_text` | ✅ | ✅ |
| `json_object_keys` / `jsonb_object_keys` | ✅ | ✅ |
| `json_each` / `jsonb_each` / `json_each_text` / `jsonb_each_text` | — (STRUCT results panic the wire serializer) | ✅ |

Each name is created as both a scalar macro (`unnest`-based, for `SELECT json_array_elements(...)`) and a table macro (for `FROM json_array_elements(...)`) — DuckDB stores these in separate catalog namespaces, same trick as the existing `pg_is_in_recovery()`.

Query rewriter changes:
- Expressions inside FROM-clause and `JOIN [LATERAL]` function arguments are now remapped (previously skipped entirely), so `::jsonb` casts and schema-qualified column refs work there.
- JOINs are now remapped at **any** position in the FROM list (`FROM a, b JOIN c ON ...`). Previously only `FromClause[0]` was checked, so tables/functions inside later JOINs silently hit the empty DuckDB mirror tables instead of `iceberg_scan` — wrong results, not even an error.

Example (verified against a real workflow spec):

```sql
SELECT j.id, c.value ->> 'name' AS component, d.value AS depends_on
FROM dexter_public.job j,
     jsonb_array_elements(j.spec -> 'components') c,
     jsonb_array_elements_text(c.value -> 'depends_on') d;
```

## Behavior change

`json_object_keys`/`jsonb_object_keys` previously returned the whole key array in a single row; they now return **one row per key**, matching Postgres `SETOF` semantics.

## Pre-existing bugs fixed (found because they blocked or crashed the test suite / server)

1. **`jsonb_extract_path_text(json, VARIADIC ARRAY[...])`** was never remapped (the remapper bailed on non-const args), failing in DuckDB — and its own test panicked the harness. The `VARIADIC ARRAY[...]::text[]` cast form is also supported now.
2. **Crash-by-query class (server process death):** six unguarded `.GetSval().Sval` accesses nil-panicked the per-connection goroutine on non-string constants — `jsonb_extract_path_text(j, 1)`, `1::regclass`, `123::text[]`, `col::text[]`, `123::regproc`, `format(123, ...)`, `bemidb_last_synced_at(123)`, `1 = ANY(123)`. All now degrade to clean SQL errors or graceful fallbacks, verified over the wire.
3. **Test harness panics**: count/type mismatches indexed out of range, aborting the whole suite at a random point (Go randomizes test order). This had been hiding every failure listed below.

## Test status — full transparency

⚠️ **GitHub Actions has never run on this fork** (0 workflow runs; Actions is disabled by default on forks). `build.yml` exists but no PR was ever actually gated by tests. Recommend enabling Actions.

With the harness fixed, the full suite runs to completion. **6 pre-existing failures remain, byte-for-byte identical with and without this branch's changes** (verified by diffing failure lists of both runs):

- `PG_system_tables`: `pg_extension` oid expected `1262`, got `1531`
- `Column_types`: 4× `xid`/`xid8` wire type expected `28`/`5069`, got `20`
- `CASE`: `WHERE nsp.oid = 1268::OID` returns 0 rows

These are hardcoded DuckDB-internal catalog oids/types that drifted with earlier pixxel changes — all reproduce on clean `pixxel` HEAD (they also all exist on upstream `main`, where they pass — so a pixxel change shifted them). Out of scope here; needs a team decision on updating expectations.

The 22 new tests all pass: 19 in the `JSON functions` group (macros in both positions, lateral joins against a synced Iceberg table, `CROSS/LEFT JOIN LATERAL`, JOIN-after-comma positions, `::jsonb` casts, NULL/empty-array handling) plus 3 crash-class regressions in `PG functions`.

## Known limitations

- `WITH ORDINALITY` is not supported by DuckDB — use `row_number() OVER ()` to number elements.
- **DuckDB 1.1.3 engine bug** (reproduced in pure DuckDB, no BemiDB involved): `FROM t, json_fn(...) c LEFT JOIN LATERAL <anything referencing c> ...` fails with `INTERNAL Error: Failed to bind column reference` and **invalidates the DuckDB instance until restart**. Workaround: chain laterals with commas (`FROM t, fn(...) c, fn(c.value...) d` — works fine) or `LEFT JOIN LATERAL` directly off the base table only. Worth a runbook note for the affected instances.

## Verification

- Capabilities probed against the exact bundled engine (go-duckdb v1.8.3 / DuckDB 1.1.3) before implementation.
- Full test suite comparison run: failure set identical with/without the changes.
- End-to-end over the wire: built the binary from this branch, ran a live instance, and executed the real workflow-spec analytics via `psql` (component expansion, nested `inputs[]` AOI extraction, `depends_on` edges, data-flow edges, block-usage rollups, a 15-condition edge-case matrix, the crash-class hostile queries, and the bug-fix repros).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
