### PR TITLE
fix: release prepared statements + return freed memory to the OS (OOM ratchet)

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -52,8 +52,12 @@ func boolFromEnvDefaultTrue(key string) bool {
 	return true
 }
 
-// duckdbMemorySizeRegexp matches DuckDB memory sizes ("64MB", "1.5 GiB").
-var duckdbMemorySizeRegexp = regexp.MustCompile(`(?i)^\s*\d+(\.\d+)?\s*(B|KB|MB|GB|TB|KiB|MiB|GiB|TiB)?\s*$`)
+// duckdbMemorySizeRegexp matches exactly what DuckDB 1.1.3's own parser accepts
+// for memory sizes, measured against the engine (see the engine-agreement test):
+// a unit is required ("64" is rejected), single-letter units are legal ("64M",
+// "1G"), P* units are NOT accepted, and "-1" (unlimited) is. Kept in lockstep
+// with the engine by TestDuckdbMemorySizeRegexpMatchesEngine.
+var duckdbMemorySizeRegexp = regexp.MustCompile(`(?i)^\s*(-1|\d+(\.\d+)?\s*(B|[KMGT](IB|B)?))\s*$`)
 
 const (
 	VERSION = "0.51.1"
@@ -199,7 +203,7 @@ func registerFlags() {
 	flag.StringVar(&_config.DuckDbTempDirectory, "duckdb-temp-directory", os.Getenv(ENV_DUCKDB_TEMP_DIRECTORY), "(Optional) DuckDB temp_directory for spilling to disk. Defaults to the OS temp dir so a memory limit can spill instead of erroring.")
 	flag.IntVar(&_config.DuckDbThreads, "duckdb-threads", intFromEnv(ENV_DUCKDB_THREADS), "(Optional) DuckDB threads. Caps scan parallelism to bound peak memory. Defaults to DuckDB's own default (all host cores).")
 	flag.IntVar(&_config.MaxResultMb, "max-result-mb", intFromEnv(ENV_MAX_RESULT_MB), "(Optional) Maximum result payload in MB per query. Results are buffered in memory before sending, so unbounded results can OOM the process. 0 disables the cap.")
-	flag.BoolVar(&_config.DuckDbAllocatorBackgroundThreads, "duckdb-allocator-background-threads", boolFromEnvDefaultTrue(ENV_DUCKDB_ALLOCATOR_BACKGROUND_THREADS), "(Optional) Enable jemalloc background threads so freed memory is returned to the OS instead of retained indefinitely. Default: true; \"false\"/\"0\"/\"off\" restores DuckDB's default.")
+	flag.BoolVar(&_config.DuckDbAllocatorBackgroundThreads, "duckdb-allocator-background-threads", boolFromEnvDefaultTrue(ENV_DUCKDB_ALLOCATOR_BACKGROUND_THREADS), "(Optional) Enable jemalloc background threads so freed memory is returned to the OS instead of retained indefinitely. Default: true; \"false\"/\"0\"/\"off\"/\"no\"/\"disable(d)\" (any case, whitespace ignored) restores DuckDB's default.")
 	flag.StringVar(&_config.DuckDbAllocatorFlushThreshold, "duckdb-allocator-flush-threshold", stringFromEnvOrDefault(ENV_DUCKDB_ALLOCATOR_FLUSH_THRESHOLD, DEFAULT_DUCKDB_ALLOCATOR_FLUSH_THRESHOLD), "(Optional) DuckDB allocator_flush_threshold: flush the allocator after any task that peaked above this. Default: \""+DEFAULT_DUCKDB_ALLOCATOR_FLUSH_THRESHOLD+"\". Set \"128MB\" to restore DuckDB's own default.")
 	flag.IntVar(&_config.DuckDbConnMaxLifetimeMinutes, "duckdb-conn-max-lifetime-minutes", intFromEnvOrDefault(ENV_DUCKDB_CONN_MAX_LIFETIME_MINUTES, DEFAULT_DUCKDB_CONN_MAX_LIFETIME_MINUTES), "(Optional) Recycle pooled DuckDB connections after N minutes (between uses, never mid-query); retained allocator memory is released when a connection closes. Default: 30. 0 disables recycling.")
 	flag.IntVar(&_config.ParquetRowGroupSizeMb, "parquet-row-group-size-mb", intFromEnv(ENV_PARQUET_ROW_GROUP_SIZE_MB), "(Optional) Parquet row group size in MB. Smaller values cap the in-memory write buffer. Default: 128")
@@ -236,6 +240,12 @@ func parseFlags() {
 	// otherwise boot "successfully" with the OOM mitigation silently absent.
 	if _config.DuckDbAllocatorFlushThreshold != "" && !duckdbMemorySizeRegexp.MatchString(_config.DuckDbAllocatorFlushThreshold) {
 		panic("--duckdb-allocator-flush-threshold (" + ENV_DUCKDB_ALLOCATOR_FLUSH_THRESHOLD + ") must be a memory size like \"64MB\", got " + _config.DuckDbAllocatorFlushThreshold)
+	}
+	// Same validation for the OOM-critical memory limit: its SET is fail-hard at
+	// boot, so catching the malformed value here names the flag instead of
+	// surfacing a raw engine error mid-startup.
+	if _config.DuckDbMemoryLimit != "" && !duckdbMemorySizeRegexp.MatchString(_config.DuckDbMemoryLimit) {
+		panic("--duckdb-memory-limit (" + ENV_DUCKDB_MEMORY_LIMIT + ") must be a memory size like \"4GB\", got " + _config.DuckDbMemoryLimit)
 	}
 
 	if _config.Host == "" {

--- a/src/config.go
+++ b/src/config.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -39,15 +40,20 @@ func stringFromEnvOrDefault(key string, defaultValue string) string {
 }
 
 // boolFromEnvDefaultTrue is for flags that default to on: unset/empty is true,
-// and disabling requires an explicit "false"/"0"/"off" (any case) — so that
-// e.g. FALSE or 0 don't silently leave the feature enabled.
+// and disabling requires an explicit negative — any case, surrounding
+// whitespace ignored (k8s configmaps and .env files produce "false " and
+// "off\n" easily, and a silently-still-enabled feature is the exact footgun
+// this helper exists to prevent).
 func boolFromEnvDefaultTrue(key string) bool {
-	switch strings.ToLower(os.Getenv(key)) {
-	case "false", "0", "off":
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(key))) {
+	case "false", "0", "off", "no", "disable", "disabled":
 		return false
 	}
 	return true
 }
+
+// duckdbMemorySizeRegexp matches DuckDB memory sizes ("64MB", "1.5 GiB").
+var duckdbMemorySizeRegexp = regexp.MustCompile(`(?i)^\s*\d+(\.\d+)?\s*(B|KB|MB|GB|TB|KiB|MiB|GiB|TiB)?\s*$`)
 
 const (
 	VERSION = "0.51.1"
@@ -223,6 +229,13 @@ func parseFlags() {
 	// operator believes they are protected.
 	if _config.MaxResultMb < 0 {
 		panic("--max-result-mb (BEMIDB_MAX_RESULT_MB) must be >= 0, got " + IntToString(_config.MaxResultMb))
+	}
+
+	// Fail fast on a malformed memory size: the SET it feeds is fail-soft
+	// (engine rejection must not crash boot), so a typo like "64XB" would
+	// otherwise boot "successfully" with the OOM mitigation silently absent.
+	if _config.DuckDbAllocatorFlushThreshold != "" && !duckdbMemorySizeRegexp.MatchString(_config.DuckDbAllocatorFlushThreshold) {
+		panic("--duckdb-allocator-flush-threshold (" + ENV_DUCKDB_ALLOCATOR_FLUSH_THRESHOLD + ") must be a memory size like \"64MB\", got " + _config.DuckDbAllocatorFlushThreshold)
 	}
 
 	if _config.Host == "" {

--- a/src/config.go
+++ b/src/config.go
@@ -38,6 +38,17 @@ func stringFromEnvOrDefault(key string, defaultValue string) string {
 	return defaultValue
 }
 
+// boolFromEnvDefaultTrue is for flags that default to on: unset/empty is true,
+// and disabling requires an explicit "false"/"0"/"off" (any case) — so that
+// e.g. FALSE or 0 don't silently leave the feature enabled.
+func boolFromEnvDefaultTrue(key string) bool {
+	switch strings.ToLower(os.Getenv(key)) {
+	case "false", "0", "off":
+		return false
+	}
+	return true
+}
+
 const (
 	VERSION = "0.51.1"
 
@@ -95,6 +106,9 @@ const (
 	DEFAULT_DB_STORAGE_TYPE = "LOCAL"
 
 	DEFAULT_AWS_S3_ENDPOINT = "s3.amazonaws.com"
+
+	DEFAULT_DUCKDB_ALLOCATOR_FLUSH_THRESHOLD = "64MB"
+	DEFAULT_DUCKDB_CONN_MAX_LIFETIME_MINUTES = 30
 
 	PPROF_PORT = "6060"
 
@@ -179,9 +193,9 @@ func registerFlags() {
 	flag.StringVar(&_config.DuckDbTempDirectory, "duckdb-temp-directory", os.Getenv(ENV_DUCKDB_TEMP_DIRECTORY), "(Optional) DuckDB temp_directory for spilling to disk. Defaults to the OS temp dir so a memory limit can spill instead of erroring.")
 	flag.IntVar(&_config.DuckDbThreads, "duckdb-threads", intFromEnv(ENV_DUCKDB_THREADS), "(Optional) DuckDB threads. Caps scan parallelism to bound peak memory. Defaults to DuckDB's own default (all host cores).")
 	flag.IntVar(&_config.MaxResultMb, "max-result-mb", intFromEnv(ENV_MAX_RESULT_MB), "(Optional) Maximum result payload in MB per query. Results are buffered in memory before sending, so unbounded results can OOM the process. 0 disables the cap.")
-	flag.BoolVar(&_config.DuckDbAllocatorBackgroundThreads, "duckdb-allocator-background-threads", os.Getenv(ENV_DUCKDB_ALLOCATOR_BACKGROUND_THREADS) != "false", "(Optional) Enable jemalloc background threads so freed memory is returned to the OS instead of retained indefinitely. Default: true; set to false to restore DuckDB's default.")
-	flag.StringVar(&_config.DuckDbAllocatorFlushThreshold, "duckdb-allocator-flush-threshold", stringFromEnvOrDefault(ENV_DUCKDB_ALLOCATOR_FLUSH_THRESHOLD, "64MB"), "(Optional) DuckDB allocator_flush_threshold: flush the allocator after any task that peaked above this. Default: \"64MB\" (DuckDB's own default is 128MB). Empty leaves DuckDB's default.")
-	flag.IntVar(&_config.DuckDbConnMaxLifetimeMinutes, "duckdb-conn-max-lifetime-minutes", intFromEnvOrDefault(ENV_DUCKDB_CONN_MAX_LIFETIME_MINUTES, 30), "(Optional) Recycle pooled DuckDB connections after N minutes (between uses, never mid-query); retained allocator memory is released when a connection closes. Default: 30. 0 disables recycling.")
+	flag.BoolVar(&_config.DuckDbAllocatorBackgroundThreads, "duckdb-allocator-background-threads", boolFromEnvDefaultTrue(ENV_DUCKDB_ALLOCATOR_BACKGROUND_THREADS), "(Optional) Enable jemalloc background threads so freed memory is returned to the OS instead of retained indefinitely. Default: true; \"false\"/\"0\"/\"off\" restores DuckDB's default.")
+	flag.StringVar(&_config.DuckDbAllocatorFlushThreshold, "duckdb-allocator-flush-threshold", stringFromEnvOrDefault(ENV_DUCKDB_ALLOCATOR_FLUSH_THRESHOLD, DEFAULT_DUCKDB_ALLOCATOR_FLUSH_THRESHOLD), "(Optional) DuckDB allocator_flush_threshold: flush the allocator after any task that peaked above this. Default: \""+DEFAULT_DUCKDB_ALLOCATOR_FLUSH_THRESHOLD+"\". Set \"128MB\" to restore DuckDB's own default.")
+	flag.IntVar(&_config.DuckDbConnMaxLifetimeMinutes, "duckdb-conn-max-lifetime-minutes", intFromEnvOrDefault(ENV_DUCKDB_CONN_MAX_LIFETIME_MINUTES, DEFAULT_DUCKDB_CONN_MAX_LIFETIME_MINUTES), "(Optional) Recycle pooled DuckDB connections after N minutes (between uses, never mid-query); retained allocator memory is released when a connection closes. Default: 30. 0 disables recycling.")
 	flag.IntVar(&_config.ParquetRowGroupSizeMb, "parquet-row-group-size-mb", intFromEnv(ENV_PARQUET_ROW_GROUP_SIZE_MB), "(Optional) Parquet row group size in MB. Smaller values cap the in-memory write buffer. Default: 128")
 	flag.IntVar(&_config.ParquetPayloadThresholdMb, "parquet-payload-threshold-mb", intFromEnv(ENV_PARQUET_PAYLOAD_THRESHOLD_MB), "(Optional) Uncompressed payload (MB) per Parquet file before rolling to a new file. Default: 2048")
 	flag.StringVar(&_config.StoragePath, "storage-path", os.Getenv(ENV_STORAGE_PATH), "Path to the storage folder. Default: \""+DEFAULT_STORAGE_PATH+"\"")

--- a/src/config.go
+++ b/src/config.go
@@ -24,6 +24,20 @@ func intFromEnv(key string) int {
 	return v
 }
 
+func intFromEnvOrDefault(key string, defaultValue int) int {
+	if os.Getenv(key) == "" {
+		return defaultValue
+	}
+	return intFromEnv(key)
+}
+
+func stringFromEnvOrDefault(key string, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}
+
 const (
 	VERSION = "0.51.1"
 
@@ -57,10 +71,13 @@ const (
 	ENV_METRICS_PORT          = "BEMIDB_METRICS_PORT"
 	ENV_MEMORY_SAMPLE_SECONDS = "BEMIDB_MEMORY_SAMPLE_SECONDS"
 
-	ENV_DUCKDB_MEMORY_LIMIT   = "BEMIDB_DUCKDB_MEMORY_LIMIT"
-	ENV_DUCKDB_TEMP_DIRECTORY = "BEMIDB_DUCKDB_TEMP_DIRECTORY"
-	ENV_DUCKDB_THREADS        = "BEMIDB_DUCKDB_THREADS"
-	ENV_MAX_RESULT_MB         = "BEMIDB_MAX_RESULT_MB"
+	ENV_DUCKDB_MEMORY_LIMIT                 = "BEMIDB_DUCKDB_MEMORY_LIMIT"
+	ENV_DUCKDB_TEMP_DIRECTORY               = "BEMIDB_DUCKDB_TEMP_DIRECTORY"
+	ENV_DUCKDB_THREADS                      = "BEMIDB_DUCKDB_THREADS"
+	ENV_MAX_RESULT_MB                       = "BEMIDB_MAX_RESULT_MB"
+	ENV_DUCKDB_ALLOCATOR_BACKGROUND_THREADS = "BEMIDB_DUCKDB_ALLOCATOR_BACKGROUND_THREADS"
+	ENV_DUCKDB_ALLOCATOR_FLUSH_THRESHOLD    = "BEMIDB_DUCKDB_ALLOCATOR_FLUSH_THRESHOLD"
+	ENV_DUCKDB_CONN_MAX_LIFETIME_MINUTES    = "BEMIDB_DUCKDB_CONN_MAX_LIFETIME_MINUTES"
 
 	ENV_PARQUET_ROW_GROUP_SIZE_MB    = "BEMIDB_PARQUET_ROW_GROUP_SIZE_MB"
 	ENV_PARQUET_PAYLOAD_THRESHOLD_MB = "BEMIDB_PARQUET_PAYLOAD_THRESHOLD_MB"
@@ -106,28 +123,31 @@ type PgConfig struct {
 }
 
 type Config struct {
-	Host                      string
-	Port                      string
-	Database                  string
-	User                      string
-	EncryptedPassword         string
-	EnableCache               bool
-	EnableHttpConnectionCache bool
-	EnablePprof               bool
-	MetricsPort               string
-	MemorySampleSeconds       int
-	DuckDbMemoryLimit         string
-	DuckDbTempDirectory       string
-	DuckDbThreads             int
-	MaxResultMb               int
-	ParquetRowGroupSizeMb     int
-	ParquetPayloadThresholdMb int
-	LogLevel                  string
-	StorageType               string
-	StoragePath               string
-	Aws                       AwsConfig
-	Pg                        PgConfig
-	DisableAnonymousAnalytics bool
+	Host                             string
+	Port                             string
+	Database                         string
+	User                             string
+	EncryptedPassword                string
+	EnableCache                      bool
+	EnableHttpConnectionCache        bool
+	EnablePprof                      bool
+	MetricsPort                      string
+	MemorySampleSeconds              int
+	DuckDbMemoryLimit                string
+	DuckDbTempDirectory              string
+	DuckDbThreads                    int
+	MaxResultMb                      int
+	DuckDbAllocatorBackgroundThreads bool
+	DuckDbAllocatorFlushThreshold    string
+	DuckDbConnMaxLifetimeMinutes     int
+	ParquetRowGroupSizeMb            int
+	ParquetPayloadThresholdMb        int
+	LogLevel                         string
+	StorageType                      string
+	StoragePath                      string
+	Aws                              AwsConfig
+	Pg                               PgConfig
+	DisableAnonymousAnalytics        bool
 }
 
 type configParseValues struct {
@@ -159,6 +179,9 @@ func registerFlags() {
 	flag.StringVar(&_config.DuckDbTempDirectory, "duckdb-temp-directory", os.Getenv(ENV_DUCKDB_TEMP_DIRECTORY), "(Optional) DuckDB temp_directory for spilling to disk. Defaults to the OS temp dir so a memory limit can spill instead of erroring.")
 	flag.IntVar(&_config.DuckDbThreads, "duckdb-threads", intFromEnv(ENV_DUCKDB_THREADS), "(Optional) DuckDB threads. Caps scan parallelism to bound peak memory. Defaults to DuckDB's own default (all host cores).")
 	flag.IntVar(&_config.MaxResultMb, "max-result-mb", intFromEnv(ENV_MAX_RESULT_MB), "(Optional) Maximum result payload in MB per query. Results are buffered in memory before sending, so unbounded results can OOM the process. 0 disables the cap.")
+	flag.BoolVar(&_config.DuckDbAllocatorBackgroundThreads, "duckdb-allocator-background-threads", os.Getenv(ENV_DUCKDB_ALLOCATOR_BACKGROUND_THREADS) != "false", "(Optional) Enable jemalloc background threads so freed memory is returned to the OS instead of retained indefinitely. Default: true; set to false to restore DuckDB's default.")
+	flag.StringVar(&_config.DuckDbAllocatorFlushThreshold, "duckdb-allocator-flush-threshold", stringFromEnvOrDefault(ENV_DUCKDB_ALLOCATOR_FLUSH_THRESHOLD, "64MB"), "(Optional) DuckDB allocator_flush_threshold: flush the allocator after any task that peaked above this. Default: \"64MB\" (DuckDB's own default is 128MB). Empty leaves DuckDB's default.")
+	flag.IntVar(&_config.DuckDbConnMaxLifetimeMinutes, "duckdb-conn-max-lifetime-minutes", intFromEnvOrDefault(ENV_DUCKDB_CONN_MAX_LIFETIME_MINUTES, 30), "(Optional) Recycle pooled DuckDB connections after N minutes (between uses, never mid-query); retained allocator memory is released when a connection closes. Default: 30. 0 disables recycling.")
 	flag.IntVar(&_config.ParquetRowGroupSizeMb, "parquet-row-group-size-mb", intFromEnv(ENV_PARQUET_ROW_GROUP_SIZE_MB), "(Optional) Parquet row group size in MB. Smaller values cap the in-memory write buffer. Default: 128")
 	flag.IntVar(&_config.ParquetPayloadThresholdMb, "parquet-payload-threshold-mb", intFromEnv(ENV_PARQUET_PAYLOAD_THRESHOLD_MB), "(Optional) Uncompressed payload (MB) per Parquet file before rolling to a new file. Default: 2048")
 	flag.StringVar(&_config.StoragePath, "storage-path", os.Getenv(ENV_STORAGE_PATH), "Path to the storage folder. Default: \""+DEFAULT_STORAGE_PATH+"\"")

--- a/src/duckdb.go
+++ b/src/duckdb.go
@@ -4,13 +4,14 @@ import (
 	"bufio"
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"io"
 	"regexp"
 	"slices"
 	"strings"
 	"time"
 
-	_ "github.com/marcboeker/go-duckdb"
+	duckDb "github.com/marcboeker/go-duckdb"
 )
 
 const (
@@ -18,6 +19,8 @@ const (
 	REFRESH_IMPLICIT_AWS_CREDENTIALS_INTERVAL = 10 * time.Minute
 )
 
+// Instance-wide setup: extensions and catalog state live on the shared database
+// instance, so these run once at boot on whichever connection serves it.
 var DUCKDB_INIT_BOOT_QUERIES = []string{
 	// Set up Iceberg
 	"INSTALL iceberg",
@@ -28,9 +31,19 @@ var DUCKDB_INIT_BOOT_QUERIES = []string{
 
 	// Set up schemas
 	"SELECT oid FROM pg_catalog.pg_namespace",
-	"CREATE SCHEMA public",
+}
 
-	// Configure DuckDB
+// Session-scoped setup: SET timezone, SET scalar_subquery_error_on_multiple_rows,
+// and USE apply to a single DuckDB connection, and the sql.DB pool creates and
+// recycles connections over time (SetConnMaxLifetime). Applied once at boot they
+// silently vanish on the first recycled connection — timezone flips to host-local,
+// the current schema reverts to main, multi-row scalar subqueries start erroring —
+// so they run in the driver's per-connection init hook instead. CREATE SCHEMA is
+// catalog-wide but sits here (idempotent) because USE public needs it to exist
+// before the boot queries have run on the very first connection.
+var DUCKDB_SESSION_INIT_QUERIES = []string{
+	"CREATE SCHEMA IF NOT EXISTS public",
+	"USE public",
 	"SET scalar_subquery_error_on_multiple_rows=false",
 	"SET timezone='UTC'",
 }
@@ -43,8 +56,25 @@ type Duckdb struct {
 
 func NewDuckdb(config *Config, withPgCompatibility bool) *Duckdb {
 	ctx := context.Background()
-	db, err := sql.Open("duckdb", "")
+
+	// The init hook runs on every connection the pool creates — the only way
+	// session-scoped state survives connection recycling (see
+	// DUCKDB_SESSION_INIT_QUERIES). Sync instances keep their current behavior:
+	// they never ran session setup, so their hook stays nil.
+	var connInitFn func(execer driver.ExecerContext) error
+	if withPgCompatibility {
+		connInitFn = func(execer driver.ExecerContext) error {
+			for _, query := range DUCKDB_SESSION_INIT_QUERIES {
+				if _, err := execer.ExecContext(ctx, query, nil); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+	}
+	connector, err := duckDb.NewConnector("", connInitFn)
 	PanicIfError(config, err)
+	db := sql.OpenDB(connector)
 
 	// Recycle pooled DuckDB connections periodically. Measured on this engine:
 	// jemalloc's retained (freed-but-held) memory pins to long-lived connections
@@ -73,15 +103,27 @@ func NewDuckdb(config *Config, withPgCompatibility bool) *Duckdb {
 			// Create pg-compatible tables and views
 			CreatePgCatalogTableQueries(config),
 			CreateInformationSchemaTableQueries(config),
-
-			// Use the public schema
-			[]string{"USE public"},
 		)
 	}
 
-	for _, query := range bootQueries {
-		_, err := duckdb.ExecContext(ctx, query, nil)
+	if withPgCompatibility {
+		// Pin a single pooled connection for the boot sequence. The pg-compat
+		// macros/views below are created unqualified and must land in main, where
+		// they have always lived (USE public used to run only after them; session
+		// resolution finds them via the main fallback). The session hook has
+		// already switched this connection to public, so flip it to main for
+		// creation and hand it back on public, matching every other connection.
+		conn, err := db.Conn(ctx)
 		PanicIfError(config, err)
+		_, err = conn.ExecContext(ctx, "USE main")
+		PanicIfError(config, err)
+		for _, query := range bootQueries {
+			_, err := conn.ExecContext(ctx, query)
+			PanicIfError(config, err)
+		}
+		_, err = conn.ExecContext(ctx, "USE public")
+		PanicIfError(config, err)
+		PanicIfError(config, conn.Close())
 	}
 
 	// Return freed memory to the OS. DuckDB's bundled jemalloc retains freed
@@ -91,16 +133,20 @@ func NewDuckdb(config *Config, withPgCompatibility bool) *Duckdb {
 	// workload held 1.2GiB at idle with the defaults, 73MiB with these two).
 	// Background threads purge asynchronously; the lower flush threshold
 	// (default 128MB) extends the post-task flush to mid-size queries.
-	// Accepted as no-ops by builds without jemalloc (e.g. macOS).
+	// Fail-soft: these are GLOBAL-scope optimizations, not correctness — a bad
+	// value or an engine that drops the setting must not turn the OOM fix into
+	// a boot crash. (No-ops on builds without jemalloc, e.g. macOS.)
 	if config.DuckDbAllocatorBackgroundThreads {
-		_, err := duckdb.ExecContext(ctx, "SET allocator_background_threads=true", nil)
-		PanicIfError(config, err)
+		if _, err := duckdb.ExecContext(ctx, "SET allocator_background_threads=true", nil); err != nil {
+			LogError(config, "DuckDB: failed to enable allocator background threads:", err)
+		}
 	}
 	if config.DuckDbAllocatorFlushThreshold != "" {
-		_, err := duckdb.ExecContext(ctx, "SET allocator_flush_threshold='"+config.DuckDbAllocatorFlushThreshold+"'", nil)
-		PanicIfError(config, err)
-		LogInfo(config, "DuckDB: allocator background_threads:", config.DuckDbAllocatorBackgroundThreads, "flush_threshold:", config.DuckDbAllocatorFlushThreshold)
+		if _, err := duckdb.ExecContext(ctx, "SET allocator_flush_threshold='"+config.DuckDbAllocatorFlushThreshold+"'", nil); err != nil {
+			LogError(config, "DuckDB: failed to set allocator_flush_threshold:", err)
+		}
 	}
+	LogInfo(config, "DuckDB: allocator background_threads:", config.DuckDbAllocatorBackgroundThreads, "flush_threshold:", config.DuckDbAllocatorFlushThreshold)
 
 	// Point DuckDB at a temp directory so larger-than-memory operations (joins,
 	// aggregates, sorts, and the sync merge) spill to disk instead of erroring.

--- a/src/duckdb.go
+++ b/src/duckdb.go
@@ -30,11 +30,12 @@ var DUCKDB_INIT_BOOT_QUERIES = []string{
 	"INSTALL spatial",
 	"LOAD spatial",
 
-	// Preload ICU: the session hook's SET timezone would otherwise autoload it,
-	// and concurrent fresh connections racing that autoload poison the instance
-	// permanently ("icu_sort_key already exists"). Loading it here, on the
-	// single pinned boot connection, makes the hook autoload-free by design
-	// rather than shielded by boot ordering.
+	// Preload ICU: the session hook's SET timezone autoloads it, and concurrent
+	// fresh connections racing that autoload poison the instance permanently
+	// ("icu_sort_key already exists"). Note the boot connection's own hook still
+	// autoloads ICU (hooks run before this list) — that is safe only because
+	// boot is single-threaded and completes before the server accepts clients;
+	// every connection after boot finds ICU loaded and autoloads nothing.
 	"INSTALL icu",
 	"LOAD icu",
 

--- a/src/duckdb.go
+++ b/src/duckdb.go
@@ -46,6 +46,14 @@ func NewDuckdb(config *Config, withPgCompatibility bool) *Duckdb {
 	db, err := sql.Open("duckdb", "")
 	PanicIfError(config, err)
 
+	// Recycle pooled DuckDB connections periodically. Measured on this engine:
+	// jemalloc's retained (freed-but-held) memory pins to long-lived connections
+	// and is only returned to the OS when they close. database/sql rotates a
+	// connection strictly between uses — never mid-query, invisible to clients.
+	if config.DuckDbConnMaxLifetimeMinutes > 0 {
+		db.SetConnMaxLifetime(time.Duration(config.DuckDbConnMaxLifetimeMinutes) * time.Minute)
+	}
+
 	duckdb := &Duckdb{
 		db:                                    db,
 		config:                                config,
@@ -74,6 +82,24 @@ func NewDuckdb(config *Config, withPgCompatibility bool) *Duckdb {
 	for _, query := range bootQueries {
 		_, err := duckdb.ExecContext(ctx, query, nil)
 		PanicIfError(config, err)
+	}
+
+	// Return freed memory to the OS. DuckDB's bundled jemalloc retains freed
+	// allocations indefinitely by default — the right trade for an embedded
+	// notebook, but on a long-lived server the retained pages accumulate with
+	// every heavy query until the kernel OOM-kills the pod (measured: a scan
+	// workload held 1.2GiB at idle with the defaults, 73MiB with these two).
+	// Background threads purge asynchronously; the lower flush threshold
+	// (default 128MB) extends the post-task flush to mid-size queries.
+	// Accepted as no-ops by builds without jemalloc (e.g. macOS).
+	if config.DuckDbAllocatorBackgroundThreads {
+		_, err := duckdb.ExecContext(ctx, "SET allocator_background_threads=true", nil)
+		PanicIfError(config, err)
+	}
+	if config.DuckDbAllocatorFlushThreshold != "" {
+		_, err := duckdb.ExecContext(ctx, "SET allocator_flush_threshold='"+config.DuckDbAllocatorFlushThreshold+"'", nil)
+		PanicIfError(config, err)
+		LogInfo(config, "DuckDB: allocator background_threads:", config.DuckDbAllocatorBackgroundThreads, "flush_threshold:", config.DuckDbAllocatorFlushThreshold)
 	}
 
 	// Point DuckDB at a temp directory so larger-than-memory operations (joins,

--- a/src/duckdb.go
+++ b/src/duckdb.go
@@ -38,12 +38,11 @@ var DUCKDB_INIT_BOOT_QUERIES = []string{
 // recycles connections over time (SetConnMaxLifetime). Applied once at boot they
 // silently vanish on the first recycled connection — timezone flips to host-local,
 // the current schema reverts to main, multi-row scalar subqueries start erroring —
-// so they run in the driver's per-connection init hook instead. CREATE SCHEMA is
-// catalog-wide but sits here (idempotent) because USE public needs it to exist
-// before the boot queries have run on the very first connection.
+// so they run in the driver's per-connection init hook instead. These SETs are
+// deliberately fail-hard there: a session with the wrong timezone or subquery
+// semantics is worse than a failed connection. USE public is handled separately
+// in the hook (it needs the schema to exist; see connInitFn).
 var DUCKDB_SESSION_INIT_QUERIES = []string{
-	"CREATE SCHEMA IF NOT EXISTS public",
-	"USE public",
 	"SET scalar_subquery_error_on_multiple_rows=false",
 	"SET timezone='UTC'",
 }
@@ -52,6 +51,18 @@ type Duckdb struct {
 	db                                    *sql.DB
 	config                                *Config
 	stopImplicitAwsCredentialsRefreshChan chan struct{}
+}
+
+// readDuckdbSetting returns the engine's current value for a setting, or
+// "unavailable" — for confirmation logs that must report applied state, not
+// configured intent.
+func readDuckdbSetting(ctx context.Context, db *sql.DB, name string) string {
+	var value string
+	err := db.QueryRowContext(ctx, "SELECT value FROM duckdb_settings() WHERE name = '"+name+"'").Scan(&value)
+	if err != nil {
+		return "unavailable"
+	}
+	return value
 }
 
 func NewDuckdb(config *Config, withPgCompatibility bool) *Duckdb {
@@ -66,6 +77,18 @@ func NewDuckdb(config *Config, withPgCompatibility bool) *Duckdb {
 		connInitFn = func(execer driver.ExecerContext) error {
 			for _, query := range DUCKDB_SESSION_INIT_QUERIES {
 				if _, err := execer.ExecContext(ctx, query, nil); err != nil {
+					return err
+				}
+			}
+			// USE public needs the schema to exist, which on the very first
+			// connection it doesn't. CREATE SCHEMA IF NOT EXISTS can still lose a
+			// concurrent write-write race (proven with 16 parallel fresh
+			// connections), so the create's error is ignored and the retried USE
+			// is the arbiter. After boot this stays a single always-succeeding
+			// statement per connection.
+			if _, err := execer.ExecContext(ctx, "USE public", nil); err != nil {
+				_, _ = execer.ExecContext(ctx, "CREATE SCHEMA IF NOT EXISTS public", nil)
+				if _, err := execer.ExecContext(ctx, "USE public", nil); err != nil {
 					return err
 				}
 			}
@@ -90,9 +113,8 @@ func NewDuckdb(config *Config, withPgCompatibility bool) *Duckdb {
 		stopImplicitAwsCredentialsRefreshChan: make(chan struct{}),
 	}
 
-	bootQueries := []string{}
 	if withPgCompatibility {
-		bootQueries = slices.Concat(
+		bootQueries := slices.Concat(
 			// Set up DuckDB
 			DUCKDB_INIT_BOOT_QUERIES,
 
@@ -104,9 +126,7 @@ func NewDuckdb(config *Config, withPgCompatibility bool) *Duckdb {
 			CreatePgCatalogTableQueries(config),
 			CreateInformationSchemaTableQueries(config),
 		)
-	}
 
-	if withPgCompatibility {
 		// Pin a single pooled connection for the boot sequence. The pg-compat
 		// macros/views below are created unqualified and must land in main, where
 		// they have always lived (USE public used to run only after them; session
@@ -118,6 +138,7 @@ func NewDuckdb(config *Config, withPgCompatibility bool) *Duckdb {
 		_, err = conn.ExecContext(ctx, "USE main")
 		PanicIfError(config, err)
 		for _, query := range bootQueries {
+			LogDebug(config, "Querying DuckDB:", query)
 			_, err := conn.ExecContext(ctx, query)
 			PanicIfError(config, err)
 		}
@@ -146,7 +167,10 @@ func NewDuckdb(config *Config, withPgCompatibility bool) *Duckdb {
 			LogError(config, "DuckDB: failed to set allocator_flush_threshold:", err)
 		}
 	}
-	LogInfo(config, "DuckDB: allocator background_threads:", config.DuckDbAllocatorBackgroundThreads, "flush_threshold:", config.DuckDbAllocatorFlushThreshold)
+	// Log the values the engine actually holds, not the configured intent — a
+	// rejected SET above must not produce an INFO line claiming it was applied.
+	LogInfo(config, "DuckDB: allocator background_threads:", readDuckdbSetting(ctx, db, "allocator_background_threads"),
+		"flush_threshold:", readDuckdbSetting(ctx, db, "allocator_flush_threshold"))
 
 	// Point DuckDB at a temp directory so larger-than-memory operations (joins,
 	// aggregates, sorts, and the sync merge) spill to disk instead of erroring.

--- a/src/duckdb.go
+++ b/src/duckdb.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"fmt"
 	"io"
 	"regexp"
 	"slices"
@@ -28,6 +29,14 @@ var DUCKDB_INIT_BOOT_QUERIES = []string{
 
 	"INSTALL spatial",
 	"LOAD spatial",
+
+	// Preload ICU: the session hook's SET timezone would otherwise autoload it,
+	// and concurrent fresh connections racing that autoload poison the instance
+	// permanently ("icu_sort_key already exists"). Loading it here, on the
+	// single pinned boot connection, makes the hook autoload-free by design
+	// rather than shielded by boot ordering.
+	"INSTALL icu",
+	"LOAD icu",
 
 	// Set up schemas
 	"SELECT oid FROM pg_catalog.pg_namespace",
@@ -53,13 +62,40 @@ type Duckdb struct {
 	stopImplicitAwsCredentialsRefreshChan chan struct{}
 }
 
+// duckdbSessionInitFn builds the connector init hook applied to every new
+// pooled connection: the session-scoped queries, then USE public. USE needs
+// the schema to exist, which on the very first connection it doesn't; CREATE
+// SCHEMA IF NOT EXISTS can still lose a concurrent write-write race (proven
+// with 16 parallel fresh connections), so the create's error is only reported,
+// and the retried USE is the arbiter — losers of the race converge on it.
+// After boot this stays a single always-succeeding USE per connection.
+func duckdbSessionInitFn(ctx context.Context, sessionQueries []string) func(execer driver.ExecerContext) error {
+	return func(execer driver.ExecerContext) error {
+		for _, query := range sessionQueries {
+			if _, err := execer.ExecContext(ctx, query, nil); err != nil {
+				return err
+			}
+		}
+		if _, err := execer.ExecContext(ctx, "USE public", nil); err != nil {
+			_, createErr := execer.ExecContext(ctx, "CREATE SCHEMA IF NOT EXISTS public", nil)
+			if _, err := execer.ExecContext(ctx, "USE public", nil); err != nil {
+				// Keep the create's error: when the failure isn't the benign
+				// race (disk full, catalog corruption), it is the root cause.
+				return fmt.Errorf("USE public failed after CREATE SCHEMA attempt: %w (create error: %v)", err, createErr)
+			}
+		}
+		return nil
+	}
+}
+
 // readDuckdbSetting returns the engine's current value for a setting, or
 // "unavailable" — for confirmation logs that must report applied state, not
 // configured intent.
-func readDuckdbSetting(ctx context.Context, db *sql.DB, name string) string {
+func readDuckdbSetting(ctx context.Context, config *Config, db *sql.DB, name string) string {
+	query := "SELECT value FROM duckdb_settings() WHERE name = '" + name + "'"
+	LogDebug(config, "Querying DuckDB:", query)
 	var value string
-	err := db.QueryRowContext(ctx, "SELECT value FROM duckdb_settings() WHERE name = '"+name+"'").Scan(&value)
-	if err != nil {
+	if err := db.QueryRowContext(ctx, query).Scan(&value); err != nil {
 		return "unavailable"
 	}
 	return value
@@ -74,26 +110,7 @@ func NewDuckdb(config *Config, withPgCompatibility bool) *Duckdb {
 	// they never ran session setup, so their hook stays nil.
 	var connInitFn func(execer driver.ExecerContext) error
 	if withPgCompatibility {
-		connInitFn = func(execer driver.ExecerContext) error {
-			for _, query := range DUCKDB_SESSION_INIT_QUERIES {
-				if _, err := execer.ExecContext(ctx, query, nil); err != nil {
-					return err
-				}
-			}
-			// USE public needs the schema to exist, which on the very first
-			// connection it doesn't. CREATE SCHEMA IF NOT EXISTS can still lose a
-			// concurrent write-write race (proven with 16 parallel fresh
-			// connections), so the create's error is ignored and the retried USE
-			// is the arbiter. After boot this stays a single always-succeeding
-			// statement per connection.
-			if _, err := execer.ExecContext(ctx, "USE public", nil); err != nil {
-				_, _ = execer.ExecContext(ctx, "CREATE SCHEMA IF NOT EXISTS public", nil)
-				if _, err := execer.ExecContext(ctx, "USE public", nil); err != nil {
-					return err
-				}
-			}
-			return nil
-		}
+		connInitFn = duckdbSessionInitFn(ctx, DUCKDB_SESSION_INIT_QUERIES)
 	}
 	connector, err := duckDb.NewConnector("", connInitFn)
 	PanicIfError(config, err)
@@ -169,8 +186,8 @@ func NewDuckdb(config *Config, withPgCompatibility bool) *Duckdb {
 	}
 	// Log the values the engine actually holds, not the configured intent — a
 	// rejected SET above must not produce an INFO line claiming it was applied.
-	LogInfo(config, "DuckDB: allocator background_threads:", readDuckdbSetting(ctx, db, "allocator_background_threads"),
-		"flush_threshold:", readDuckdbSetting(ctx, db, "allocator_flush_threshold"))
+	LogInfo(config, "DuckDB: allocator background_threads:", readDuckdbSetting(ctx, config, db, "allocator_background_threads"),
+		"flush_threshold:", readDuckdbSetting(ctx, config, db, "allocator_flush_threshold"))
 
 	// Point DuckDB at a temp directory so larger-than-memory operations (joins,
 	// aggregates, sorts, and the sync merge) spill to disk instead of erroring.

--- a/src/duckdb_session_test.go
+++ b/src/duckdb_session_test.go
@@ -2,10 +2,15 @@ package main
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	duckDb "github.com/marcboeker/go-duckdb"
 )
 
 // TestSessionSettingsSurviveConnectionRecycling pins the connector init hook:
@@ -52,7 +57,97 @@ func TestSessionSettingsSurviveConnectionRecycling(t *testing.T) {
 	}
 }
 
-var setStatementRegexp = regexp.MustCompile(`(?i)^SET\s+(\w+)\s*=`)
+// TestSessionInitHookConvergesUnderConcurrentFreshConnections pins the
+// USE/create/retry arbiter in duckdbSessionInitFn: on a fresh instance with no
+// boot sequence, 16 connections race the very first CREATE SCHEMA — the class
+// where CREATE ... IF NOT EXISTS alone loses write-write conflicts and, since a
+// hook failure fails connection creation, a regression here is a permanent
+// outage, not an error. The session list here omits SET timezone on purpose:
+// its ICU autoload race is a separate instance-level hazard fixed by preloading
+// ICU in the boot list, and including it would test that shield instead of the
+// schema arbiter.
+func TestSessionInitHookConvergesUnderConcurrentFreshConnections(t *testing.T) {
+	ctx := context.Background()
+	connector, err := duckDb.NewConnector("", duckdbSessionInitFn(ctx, []string{"SET scalar_subquery_error_on_multiple_rows=false"}))
+	if err != nil {
+		t.Fatalf("connector: %v", err)
+	}
+	db := sql.OpenDB(connector)
+	defer db.Close()
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 16)
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			conn, err := db.Conn(ctx) // overlapping Conn calls force fresh physical connections
+			if err != nil {
+				errs <- fmt.Errorf("connection creation failed (hook error): %w", err)
+				return
+			}
+			defer conn.Close()
+			var schema string
+			if err := conn.QueryRowContext(ctx, "SELECT current_schema()").Scan(&schema); err != nil {
+				errs <- err
+				return
+			}
+			if schema != "public" {
+				errs <- fmt.Errorf("expected schema public, got %q", schema)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("concurrent fresh connection: %v", err)
+	}
+}
+
+// TestDuckdbMemorySizeRegexpMatchesEngine keeps the config-parse guard aligned
+// with the engine's own memory-size parser, in the two directions that matter:
+// (a) hard rule — anything the guard accepts the engine must accept, else a
+// fail-soft SET silently no-ops and the OOM mitigation is absent; (b) every
+// reasonable legal form must pass the guard, else legal config panics at boot.
+// The guard MAY reject engine-tolerated junk (the engine parses "--1"): failing
+// loud on pathological input is intent, not drift. If a DuckDB upgrade shifts
+// the parser, this fails and the regexp follows.
+func TestDuckdbMemorySizeRegexpMatchesEngine(t *testing.T) {
+	config := loadTestConfig()
+	duckdb := NewDuckdb(config, false)
+	defer duckdb.Close()
+	ctx := context.Background()
+
+	engineAccepts := func(value string) bool {
+		_, err := duckdb.ExecContext(ctx, "SET allocator_flush_threshold='"+value+"'", nil)
+		return err == nil
+	}
+
+	// (a) Everything the guard passes through must be engine-legal.
+	for _, value := range []string{
+		"64MB", "64M", "64 MB", " 64MB ", "1G", "1GiB", "1.5GB", "1kb", "0MB", "64B", "2KiB", "1TB", "1TiB", "-1",
+		"1PiB", "1P", "64", "64XB", "80%", "MB", "1.5", "--1", "64 X B",
+	} {
+		if duckdbMemorySizeRegexp.MatchString(value) && !engineAccepts(value) {
+			t.Errorf("guard accepts %q but the engine rejects it — the fail-soft SET would silently no-op; tighten duckdbMemorySizeRegexp", value)
+		}
+	}
+
+	// (b) Canonical legal forms must pass the guard (and stay engine-legal).
+	for _, value := range []string{"64MB", "64M", "1G", "1GiB", "1.5GB", "1kb", "2KiB", "1TB", "-1", "4GB", "2GB"} {
+		if !duckdbMemorySizeRegexp.MatchString(value) {
+			t.Errorf("guard rejects legal value %q — boot would panic on good config; loosen duckdbMemorySizeRegexp", value)
+		}
+		if !engineAccepts(value) {
+			t.Errorf("engine no longer accepts %q — update the canonical list and the regexp together", value)
+		}
+	}
+}
+
+// setStatementRegexp parses SET statements including an optional GLOBAL/
+// SESSION/LOCAL qualifier; the scope-guard test fails on any SET it cannot
+// parse rather than silently skipping it.
+var setStatementRegexp = regexp.MustCompile(`(?i)^SET\s+(?:(GLOBAL|SESSION|LOCAL)\s+)?(\w+)\s*=`)
 
 // TestBootAndSessionQueryScopes guards the boot/session list split with the
 // engine's own scope metadata: a session-scoped (LOCAL) SET placed in the boot
@@ -76,21 +171,45 @@ func TestBootAndSessionQueryScopes(t *testing.T) {
 		return scope
 	}
 
-	for _, query := range DUCKDB_INIT_BOOT_QUERIES {
-		match := setStatementRegexp.FindStringSubmatch(strings.TrimSpace(query))
-		if match == nil {
-			continue // not a SET statement (INSTALL/LOAD/…) — instance-wide by nature
+	// parseSet returns (qualifier, name, isSet); a SET the regexp cannot parse
+	// fails the test — an unparseable form evading the guard is how a mis-scoped
+	// SET would sneak back in.
+	parseSet := func(t *testing.T, query string) (string, string, bool) {
+		t.Helper()
+		trimmed := strings.TrimSpace(query)
+		if !strings.HasPrefix(strings.ToUpper(trimmed), "SET ") {
+			return "", "", false
 		}
-		if scope := scopeOf(t, match[1]); scope != "GLOBAL" {
+		match := setStatementRegexp.FindStringSubmatch(trimmed)
+		if match == nil {
+			t.Fatalf("SET statement %q not parseable by the scope guard — broaden setStatementRegexp", query)
+		}
+		return strings.ToUpper(match[1]), match[2], true
+	}
+
+	for _, query := range DUCKDB_INIT_BOOT_QUERIES {
+		qualifier, name, isSet := parseSet(t, query)
+		if !isSet || qualifier == "GLOBAL" { // non-SETs (INSTALL/LOAD/…) and explicit SET GLOBAL are instance-wide
+			continue
+		}
+		if qualifier == "SESSION" || qualifier == "LOCAL" {
+			t.Errorf("boot query %q is explicitly session-scoped — move it to DUCKDB_SESSION_INIT_QUERIES", query)
+			continue
+		}
+		if scope := scopeOf(t, name); scope != "GLOBAL" {
 			t.Errorf("boot query %q sets a %s-scoped setting: it will apply to one pooled connection and vanish on recycling — move it to DUCKDB_SESSION_INIT_QUERIES", query, scope)
 		}
 	}
 	for _, query := range DUCKDB_SESSION_INIT_QUERIES {
-		match := setStatementRegexp.FindStringSubmatch(strings.TrimSpace(query))
-		if match == nil {
+		qualifier, name, isSet := parseSet(t, query)
+		if !isSet || qualifier == "SESSION" || qualifier == "LOCAL" {
 			continue
 		}
-		if scope := scopeOf(t, match[1]); scope != "LOCAL" {
+		if qualifier == "GLOBAL" {
+			t.Errorf("session query %q is explicitly instance-wide — move it to the boot path", query)
+			continue
+		}
+		if scope := scopeOf(t, name); scope != "LOCAL" {
 			t.Errorf("session query %q sets a %s-scoped setting: it re-runs on every new connection for no reason — move it to the boot path", query, scope)
 		}
 	}

--- a/src/duckdb_session_test.go
+++ b/src/duckdb_session_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"regexp"
+	"strings"
 	"testing"
 	"time"
 )
@@ -46,6 +48,50 @@ func TestSessionSettingsSurviveConnectionRecycling(t *testing.T) {
 		row = duckdb.db.QueryRowContext(ctx, "SELECT (SELECT 1 FROM (VALUES (1), (2)) t(x))")
 		if err := row.Scan(&value); err != nil {
 			t.Fatalf("iteration %d: multi-row scalar subquery errored after recycling (SET scalar_subquery_error_on_multiple_rows lost): %v", i, err)
+		}
+	}
+}
+
+var setStatementRegexp = regexp.MustCompile(`(?i)^SET\s+(\w+)\s*=`)
+
+// TestBootAndSessionQueryScopes guards the boot/session list split with the
+// engine's own scope metadata: a session-scoped (LOCAL) SET placed in the boot
+// list is applied to one pooled connection and silently vanishes on recycling —
+// the exact bug the session hook exists to prevent — and the recycling test
+// only asserts the settings it knows about. The inverse (a GLOBAL SET in the
+// session list) is redundant per-connection work and belongs at boot.
+func TestBootAndSessionQueryScopes(t *testing.T) {
+	config := loadTestConfig()
+	duckdb := NewDuckdb(config, true)
+	defer duckdb.Close()
+	ctx := context.Background()
+
+	scopeOf := func(t *testing.T, settingName string) string {
+		t.Helper()
+		var scope string
+		row := duckdb.db.QueryRowContext(ctx, "SELECT scope FROM duckdb_settings() WHERE lower(name) = lower('"+settingName+"')")
+		if err := row.Scan(&scope); err != nil {
+			t.Fatalf("could not determine scope of setting %q: %v", settingName, err)
+		}
+		return scope
+	}
+
+	for _, query := range DUCKDB_INIT_BOOT_QUERIES {
+		match := setStatementRegexp.FindStringSubmatch(strings.TrimSpace(query))
+		if match == nil {
+			continue // not a SET statement (INSTALL/LOAD/…) — instance-wide by nature
+		}
+		if scope := scopeOf(t, match[1]); scope != "GLOBAL" {
+			t.Errorf("boot query %q sets a %s-scoped setting: it will apply to one pooled connection and vanish on recycling — move it to DUCKDB_SESSION_INIT_QUERIES", query, scope)
+		}
+	}
+	for _, query := range DUCKDB_SESSION_INIT_QUERIES {
+		match := setStatementRegexp.FindStringSubmatch(strings.TrimSpace(query))
+		if match == nil {
+			continue
+		}
+		if scope := scopeOf(t, match[1]); scope != "LOCAL" {
+			t.Errorf("session query %q sets a %s-scoped setting: it re-runs on every new connection for no reason — move it to the boot path", query, scope)
 		}
 	}
 }

--- a/src/duckdb_session_test.go
+++ b/src/duckdb_session_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestSessionSettingsSurviveConnectionRecycling pins the connector init hook:
+// USE public, SET timezone, and SET scalar_subquery_error_on_multiple_rows are
+// session-scoped, and the sql.DB pool recycles connections (SetConnMaxLifetime).
+// Applied once at boot they vanish on the first recycled connection — current
+// schema reverts to main, timestamps flip to host-local, multi-row scalar
+// subqueries start erroring. With a 1ms lifetime every checkout gets a brand-new
+// connection, so each iteration exercises a fresh session.
+func TestSessionSettingsSurviveConnectionRecycling(t *testing.T) {
+	config := loadTestConfig()
+	duckdb := NewDuckdb(config, true)
+	defer duckdb.Close()
+
+	duckdb.db.SetConnMaxLifetime(time.Millisecond)
+	ctx := context.Background()
+
+	for i := 0; i < 10; i++ {
+		time.Sleep(5 * time.Millisecond) // let the pooled connection expire
+
+		var schema string
+		row := duckdb.db.QueryRowContext(ctx, "SELECT current_schema()")
+		if err := row.Scan(&schema); err != nil {
+			t.Fatalf("iteration %d: current_schema: %v", i, err)
+		}
+		if schema != "public" {
+			t.Fatalf("iteration %d: current schema reverted to %q after recycling (USE public lost)", i, schema)
+		}
+
+		var timezone string
+		row = duckdb.db.QueryRowContext(ctx, "SELECT value FROM duckdb_settings() WHERE name = 'TimeZone'")
+		if err := row.Scan(&timezone); err != nil {
+			t.Fatalf("iteration %d: timezone lookup: %v", i, err)
+		}
+		if timezone != "UTC" {
+			t.Fatalf("iteration %d: timezone reverted to %q after recycling (SET timezone lost)", i, timezone)
+		}
+
+		var value int
+		row = duckdb.db.QueryRowContext(ctx, "SELECT (SELECT 1 FROM (VALUES (1), (2)) t(x))")
+		if err := row.Scan(&value); err != nil {
+			t.Fatalf("iteration %d: multi-row scalar subquery errored after recycling (SET scalar_subquery_error_on_multiple_rows lost): %v", i, err)
+		}
+	}
+}

--- a/src/duckdb_session_test.go
+++ b/src/duckdb_session_test.go
@@ -75,32 +75,42 @@ func TestSessionInitHookConvergesUnderConcurrentFreshConnections(t *testing.T) {
 	db := sql.OpenDB(connector)
 	defer db.Close()
 
+	// A start gate releases all goroutines at once, and no connection is closed
+	// until every acquisition finished — the pool can't serve a reused
+	// connection, so all 16 hooks run concurrently on a schema-less catalog
+	// every time (without the gate the race is only hit probabilistically).
+	startGate := make(chan struct{})
 	var wg sync.WaitGroup
+	acquired := make(chan *sql.Conn, 16)
 	errs := make(chan error, 16)
 	for i := 0; i < 16; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			conn, err := db.Conn(ctx) // overlapping Conn calls force fresh physical connections
+			<-startGate
+			conn, err := db.Conn(ctx)
 			if err != nil {
 				errs <- fmt.Errorf("connection creation failed (hook error): %w", err)
 				return
 			}
-			defer conn.Close()
-			var schema string
-			if err := conn.QueryRowContext(ctx, "SELECT current_schema()").Scan(&schema); err != nil {
-				errs <- err
-				return
-			}
-			if schema != "public" {
-				errs <- fmt.Errorf("expected schema public, got %q", schema)
-			}
+			acquired <- conn
 		}()
 	}
+	close(startGate)
 	wg.Wait()
+	close(acquired)
 	close(errs)
 	for err := range errs {
 		t.Errorf("concurrent fresh connection: %v", err)
+	}
+	for conn := range acquired {
+		var schema string
+		if err := conn.QueryRowContext(ctx, "SELECT current_schema()").Scan(&schema); err != nil {
+			t.Errorf("current_schema on initialized connection: %v", err)
+		} else if schema != "public" {
+			t.Errorf("expected schema public, got %q", schema)
+		}
+		conn.Close()
 	}
 }
 
@@ -118,8 +128,12 @@ func TestDuckdbMemorySizeRegexpMatchesEngine(t *testing.T) {
 	defer duckdb.Close()
 	ctx := context.Background()
 
-	engineAccepts := func(value string) bool {
-		_, err := duckdb.ExecContext(ctx, "SET allocator_flush_threshold='"+value+"'", nil)
+	// The guard fronts both settings, so agreement is checked against both —
+	// their grammars are identical today, but only the engine can promise that
+	// across an upgrade (e.g. memory_limit gaining percentage support).
+	settings := []string{"allocator_flush_threshold", "memory_limit"}
+	engineAccepts := func(setting, value string) bool {
+		_, err := duckdb.ExecContext(ctx, "SET "+setting+"='"+value+"'", nil)
 		return err == nil
 	}
 
@@ -128,8 +142,10 @@ func TestDuckdbMemorySizeRegexpMatchesEngine(t *testing.T) {
 		"64MB", "64M", "64 MB", " 64MB ", "1G", "1GiB", "1.5GB", "1kb", "0MB", "64B", "2KiB", "1TB", "1TiB", "-1",
 		"1PiB", "1P", "64", "64XB", "80%", "MB", "1.5", "--1", "64 X B",
 	} {
-		if duckdbMemorySizeRegexp.MatchString(value) && !engineAccepts(value) {
-			t.Errorf("guard accepts %q but the engine rejects it — the fail-soft SET would silently no-op; tighten duckdbMemorySizeRegexp", value)
+		for _, setting := range settings {
+			if duckdbMemorySizeRegexp.MatchString(value) && !engineAccepts(setting, value) {
+				t.Errorf("guard accepts %q but the engine rejects it for %s — the SET would fail; tighten duckdbMemorySizeRegexp", value, setting)
+			}
 		}
 	}
 
@@ -138,8 +154,10 @@ func TestDuckdbMemorySizeRegexpMatchesEngine(t *testing.T) {
 		if !duckdbMemorySizeRegexp.MatchString(value) {
 			t.Errorf("guard rejects legal value %q — boot would panic on good config; loosen duckdbMemorySizeRegexp", value)
 		}
-		if !engineAccepts(value) {
-			t.Errorf("engine no longer accepts %q — update the canonical list and the regexp together", value)
+		for _, setting := range settings {
+			if !engineAccepts(setting, value) {
+				t.Errorf("engine no longer accepts %q for %s — update the canonical list and the regexp together", value, setting)
+			}
 		}
 	}
 }

--- a/src/postgres.go
+++ b/src/postgres.go
@@ -130,16 +130,12 @@ func (postgres *Postgres) handleExtendedQuery(queryHandler *QueryHandler, parseM
 			}
 
 			LogDebug(postgres.config, "Binding query", message.PreparedStatement)
-			previous := preparedStatement
-			messages, preparedStatement, err = queryHandler.HandleBindQuery(message, previous)
+			// Handlers return the input statement even on error, so ownership (and
+			// the deferred Close) is never lost to a nil overwrite.
+			messages, preparedStatement, err = queryHandler.HandleBindQuery(message, preparedStatement)
 			if err != nil {
 				postgres.writeError(err)
 				previousErr = err
-			}
-			if preparedStatement == nil {
-				// Handlers return nil on error; keep owning the live statement so the
-				// deferred Close still releases it (and any rows it already opened).
-				preparedStatement = previous
 			}
 			postgres.writeMessages(messages...)
 		case *pgproto3.Describe:
@@ -149,16 +145,10 @@ func (postgres *Postgres) handleExtendedQuery(queryHandler *QueryHandler, parseM
 
 			LogDebug(postgres.config, "Describing query", message.Name, "("+string(message.ObjectType)+")")
 			var messages []pgproto3.Message
-			previous := preparedStatement
-			messages, preparedStatement, err = queryHandler.HandleDescribeQuery(message, previous)
+			messages, preparedStatement, err = queryHandler.HandleDescribeQuery(message, preparedStatement)
 			if err != nil {
 				postgres.writeError(err)
 				previousErr = err
-			}
-			if preparedStatement == nil {
-				// Same as Bind: don't lose the live statement (or its open rows,
-				// stored before some error returns) on the error path.
-				preparedStatement = previous
 			}
 			postgres.writeMessages(messages...)
 		case *pgproto3.Execute:
@@ -179,10 +169,19 @@ func (postgres *Postgres) handleExtendedQuery(queryHandler *QueryHandler, parseM
 			}
 
 			LogDebug(postgres.config, "Closing", string(message.ObjectType), message.Name)
-			// Client-requested release: rows and the statement itself (idempotent
-			// with the deferred Close). A later Describe/Execute on the closed
-			// statement gets an error from the guarded handlers, not a crash.
-			preparedStatement.Close()
+			// Postgres semantics: Close('S') releases the statement; Close('P')
+			// releases only the portal — the statement must stay bindable (JDBC
+			// cursor clients close portals mid-exchange and Bind again). Statement
+			// release is idempotent with the deferred Close; a later Describe/
+			// Execute on a closed statement gets an error from the guarded
+			// handlers, not a crash. (message.Name is ignored — pre-existing:
+			// BemiDB tracks a single statement per exchange.)
+			if message.ObjectType == 'S' {
+				preparedStatement.Close()
+			} else if preparedStatement.Rows != nil {
+				preparedStatement.Rows.Close()
+				preparedStatement.Rows = nil
+			}
 			postgres.writeMessages(&pgproto3.CloseComplete{})
 		case *pgproto3.Sync:
 			LogDebug(postgres.config, "Syncing query")

--- a/src/postgres.go
+++ b/src/postgres.go
@@ -110,6 +110,12 @@ func (postgres *Postgres) handleExtendedQuery(queryHandler *QueryHandler, parseM
 	}
 	postgres.writeMessages(messages...)
 
+	// Release the statement's DuckDB-side plan on every exit from this exchange —
+	// the Sync return, a dead connection, or a panic. Statements were previously
+	// never closed anywhere (database/sql requires Stmt.Close), leaking each bound
+	// plan into DuckDB's C++ memory for the life of the pooled connection.
+	defer func() { preparedStatement.Close() }()
+
 	var previousErr error
 	for {
 		message, err := postgres.backend.Receive()
@@ -124,10 +130,16 @@ func (postgres *Postgres) handleExtendedQuery(queryHandler *QueryHandler, parseM
 			}
 
 			LogDebug(postgres.config, "Binding query", message.PreparedStatement)
-			messages, preparedStatement, err = queryHandler.HandleBindQuery(message, preparedStatement)
+			previous := preparedStatement
+			messages, preparedStatement, err = queryHandler.HandleBindQuery(message, previous)
 			if err != nil {
 				postgres.writeError(err)
 				previousErr = err
+			}
+			if preparedStatement == nil {
+				// Handlers return nil on error; keep owning the live statement so the
+				// deferred Close still releases it (and any rows it already opened).
+				preparedStatement = previous
 			}
 			postgres.writeMessages(messages...)
 		case *pgproto3.Describe:
@@ -137,10 +149,16 @@ func (postgres *Postgres) handleExtendedQuery(queryHandler *QueryHandler, parseM
 
 			LogDebug(postgres.config, "Describing query", message.Name, "("+string(message.ObjectType)+")")
 			var messages []pgproto3.Message
-			messages, preparedStatement, err = queryHandler.HandleDescribeQuery(message, preparedStatement)
+			previous := preparedStatement
+			messages, preparedStatement, err = queryHandler.HandleDescribeQuery(message, previous)
 			if err != nil {
 				postgres.writeError(err)
 				previousErr = err
+			}
+			if preparedStatement == nil {
+				// Same as Bind: don't lose the live statement (or its open rows,
+				// stored before some error returns) on the error path.
+				preparedStatement = previous
 			}
 			postgres.writeMessages(messages...)
 		case *pgproto3.Execute:
@@ -161,18 +179,21 @@ func (postgres *Postgres) handleExtendedQuery(queryHandler *QueryHandler, parseM
 			}
 
 			LogDebug(postgres.config, "Closing", string(message.ObjectType), message.Name)
-			if preparedStatement.Rows != nil {
-				preparedStatement.Rows.Close()
-			}
+			// Client-requested release: rows and the statement itself (idempotent
+			// with the deferred Close). A later Describe/Execute on the closed
+			// statement gets an error from the guarded handlers, not a crash.
+			preparedStatement.Close()
 			postgres.writeMessages(&pgproto3.CloseComplete{})
 		case *pgproto3.Sync:
 			LogDebug(postgres.config, "Syncing query")
-			// Sync must always respond, so unlike the guarded cases above it runs
-			// even after an error — when a Bind/Describe failure has left
-			// preparedStatement nil. Guard the pointer, then release rows left open
-			// by a Describe that was never followed by Execute (Close is idempotent).
+			// Sync must always respond, even after an error. Release rows left open
+			// by a Describe never followed by Execute: this Sync may not exit the
+			// exchange (psycopg sends Parse->Sync->Bind->...), so rows can't wait
+			// for the deferred Close. The nil guard is defense-in-depth — error
+			// paths now restore the previous statement instead of nilling it.
 			if preparedStatement != nil && preparedStatement.Rows != nil {
 				preparedStatement.Rows.Close()
+				preparedStatement.Rows = nil
 			}
 			postgres.writeMessages(
 				&pgproto3.ReadyForQuery{TxStatus: PG_TX_STATUS_IDLE},

--- a/src/postgres.go
+++ b/src/postgres.go
@@ -171,14 +171,18 @@ func (postgres *Postgres) handleExtendedQuery(queryHandler *QueryHandler, parseM
 			LogDebug(postgres.config, "Closing", string(message.ObjectType), message.Name)
 			// Postgres semantics: Close('S') releases the statement; Close('P')
 			// releases only the portal — the statement must stay bindable (JDBC
-			// cursor clients close portals mid-exchange and Bind again). Statement
-			// release is idempotent with the deferred Close; a later Describe/
-			// Execute on a closed statement gets an error from the guarded
-			// handlers, not a crash. (message.Name is ignored — pre-existing:
-			// BemiDB tracks a single statement per exchange.)
+			// cursor clients close portals mid-exchange and Bind again). Closing a
+			// name that isn't the current one is a no-op answered with
+			// CloseComplete, like Postgres closing an unknown statement — pgjdbc
+			// statement-cache evictions interleave closes of OLD statements into
+			// the current exchange. Statement release is idempotent with the
+			// deferred Close; a later Describe/Execute on a closed statement gets
+			// an error from the guarded handlers, not a crash.
 			if message.ObjectType == 'S' {
-				preparedStatement.Close()
-			} else if preparedStatement.Rows != nil {
+				if message.Name == preparedStatement.Name {
+					preparedStatement.Close()
+				}
+			} else if message.Name == preparedStatement.Portal && preparedStatement.Rows != nil {
 				preparedStatement.Rows.Close()
 				preparedStatement.Rows = nil
 			}
@@ -188,8 +192,9 @@ func (postgres *Postgres) handleExtendedQuery(queryHandler *QueryHandler, parseM
 			// Sync must always respond, even after an error. Release rows left open
 			// by a Describe never followed by Execute: this Sync may not exit the
 			// exchange (psycopg sends Parse->Sync->Bind->...), so rows can't wait
-			// for the deferred Close. The nil guard is defense-in-depth — error
-			// paths now restore the previous statement instead of nilling it.
+			// for the deferred Close. Handlers return the statement even on error,
+			// so it can't be nil here — the guard only protects against a future
+			// handler regressing that contract.
 			if preparedStatement != nil && preparedStatement.Rows != nil {
 				preparedStatement.Rows.Close()
 				preparedStatement.Rows = nil

--- a/src/postgres_test.go
+++ b/src/postgres_test.go
@@ -8,24 +8,19 @@ import (
 	"github.com/jackc/pgx/v5/pgproto3"
 )
 
-// TestRunDoesNotPanicOnErrorBeforeSync drives the exact extended-protocol
-// sequence that used to crash the process: a parameterized query whose Bind/
-// Describe fails leaves preparedStatement nil, and the following Sync — which
-// must always respond — previously dereferenced it (SIGSEGV in the per-connection
-// goroutine, killing the whole server for every client). The server must instead
-// return an ErrorResponse and stay alive.
-func TestRunDoesNotPanicOnErrorBeforeSync(t *testing.T) {
-	createTestTables(t)
-	queryHandler := initQueryHandler()
-	defer queryHandler.duckdb.Close()
+// startTestPostgresClient boots the real connection loop (Postgres.Run) on a
+// loopback TCP socket — net.Pipe is unbuffered and deadlocks when the server
+// replies while the client is still flushing — completes the startup handshake,
+// and returns a ready frontend plus the channel closed when Run returns.
+// Cleanup of the listener and client connection is registered on t.
+func startTestPostgresClient(t *testing.T, queryHandler *QueryHandler) (*pgproto3.Frontend, chan struct{}) {
+	t.Helper()
 
-	// A real loopback socket (not net.Pipe): net.Pipe is unbuffered, so the server
-	// writing a reply while the client is still flushing later messages deadlocks.
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	defer listener.Close()
+	t.Cleanup(func() { listener.Close() })
 
 	done := make(chan struct{})
 	go func() {
@@ -44,7 +39,7 @@ func TestRunDoesNotPanicOnErrorBeforeSync(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	defer clientConn.Close()
+	t.Cleanup(func() { clientConn.Close() })
 	// Bound every read/write: without a deadline, a server that wedges before
 	// replying leaves frontend.Receive() blocked until go test's global timeout.
 	if err := clientConn.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
@@ -65,41 +60,34 @@ func TestRunDoesNotPanicOnErrorBeforeSync(t *testing.T) {
 			t.Fatalf("startup receive: %v", err)
 		}
 		if _, ok := msg.(*pgproto3.ReadyForQuery); ok {
-			break
+			return frontend, done
 		}
 	}
+}
 
-	// Bind binds a non-numeric value to $1::int; the cast error surfaces at
-	// Describe (which executes the query), leaving preparedStatement nil.
-	frontend.Send(&pgproto3.Parse{Query: "SELECT $1::int"})
-	frontend.Send(&pgproto3.Bind{Parameters: [][]byte{[]byte("not_a_number")}, ParameterFormatCodes: []int16{0}})
-	frontend.Send(&pgproto3.Describe{ObjectType: 'P'})
-	frontend.Send(&pgproto3.Execute{})
-	frontend.Send(&pgproto3.Sync{})
-	if err := frontend.Flush(); err != nil {
-		t.Fatalf("extended flush: %v", err)
-	}
-
-	sawError := false
+// receiveUntilReady drains replies until ReadyForQuery, reporting what was seen.
+func receiveUntilReady(t *testing.T, frontend *pgproto3.Frontend, step string) (sawRows bool, sawError bool) {
+	t.Helper()
 	for {
 		msg, err := frontend.Receive()
 		if err != nil {
-			t.Fatalf("expected ErrorResponse then ReadyForQuery, got receive error (server likely crashed): %v", err)
+			t.Fatalf("%s: receive error (server likely crashed): %v", step, err)
 		}
-		if _, ok := msg.(*pgproto3.ErrorResponse); ok {
+		switch msg.(type) {
+		case *pgproto3.DataRow:
+			sawRows = true
+		case *pgproto3.ErrorResponse:
 			sawError = true
-		}
-		if _, ok := msg.(*pgproto3.ReadyForQuery); ok {
-			break
+		case *pgproto3.ReadyForQuery:
+			return sawRows, sawError
 		}
 	}
-	if !sawError {
-		t.Errorf("expected an ErrorResponse for the bad parameter")
-	}
+}
 
-	// The connection loop must still be alive and serving: a Terminate ends it
-	// cleanly and Run returns. (A regression panic would crash the whole test
-	// process outright; the timeout below guards the wedged-but-alive case.)
+// terminateAndAwait ends the connection and fails the test if the server's
+// connection loop does not return (wedged or panicked).
+func terminateAndAwait(t *testing.T, frontend *pgproto3.Frontend, done chan struct{}) {
+	t.Helper()
 	frontend.Send(&pgproto3.Terminate{})
 	_ = frontend.Flush()
 	select {
@@ -109,80 +97,44 @@ func TestRunDoesNotPanicOnErrorBeforeSync(t *testing.T) {
 	}
 }
 
+// TestRunDoesNotPanicOnErrorBeforeSync drives the exact extended-protocol
+// sequence that used to crash the process: a parameterized query whose Bind/
+// Describe fails, followed by Sync — which must always respond. The server must
+// return an ErrorResponse and stay alive.
+func TestRunDoesNotPanicOnErrorBeforeSync(t *testing.T) {
+	createTestTables(t)
+	queryHandler := initQueryHandler()
+	defer queryHandler.duckdb.Close()
+	frontend, done := startTestPostgresClient(t, queryHandler)
+
+	// Bind binds a non-numeric value to $1::int; the cast error surfaces at
+	// Describe (which executes the query).
+	frontend.Send(&pgproto3.Parse{Query: "SELECT $1::int"})
+	frontend.Send(&pgproto3.Bind{Parameters: [][]byte{[]byte("not_a_number")}, ParameterFormatCodes: []int16{0}})
+	frontend.Send(&pgproto3.Describe{ObjectType: 'P'})
+	frontend.Send(&pgproto3.Execute{})
+	frontend.Send(&pgproto3.Sync{})
+	if err := frontend.Flush(); err != nil {
+		t.Fatalf("extended flush: %v", err)
+	}
+	if _, sawError := receiveUntilReady(t, frontend, "bad parameter exchange"); !sawError {
+		t.Errorf("expected an ErrorResponse for the bad parameter")
+	}
+
+	terminateAndAwait(t, frontend, done)
+}
+
 // TestExtendedQueryStatementLifecycle drives the paths where prepared statements
 // are now released (they previously leaked their DuckDB plan on every exchange):
-// two full exchanges back-to-back (deferred Close between them must not break the
-// connection), then a wire-protocol Close followed by a Describe on the released
-// statement (must error, not crash), then a final full exchange proving the
+// consecutive exchanges (deferred Close between them must not break the
+// connection), then wire-protocol Close of the statement followed by a Describe
+// on it (must error, not crash), then a final full exchange proving the
 // connection still serves.
 func TestExtendedQueryStatementLifecycle(t *testing.T) {
 	createTestTables(t)
 	queryHandler := initQueryHandler()
 	defer queryHandler.duckdb.Close()
-
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	defer listener.Close()
-
-	done := make(chan struct{})
-	go func() {
-		serverConn, acceptErr := listener.Accept()
-		if acceptErr != nil {
-			close(done)
-			return
-		}
-		postgres := NewPostgres(queryHandler.config, &serverConn)
-		postgres.Run(queryHandler)
-		serverConn.Close()
-		close(done)
-	}()
-
-	clientConn, err := net.Dial("tcp", listener.Addr().String())
-	if err != nil {
-		t.Fatalf("dial: %v", err)
-	}
-	defer clientConn.Close()
-	if err := clientConn.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
-		t.Fatalf("set deadline: %v", err)
-	}
-
-	frontend := pgproto3.NewFrontend(clientConn, clientConn)
-	frontend.Send(&pgproto3.StartupMessage{
-		ProtocolVersion: pgproto3.ProtocolVersionNumber,
-		Parameters:      map[string]string{"user": "bemidb", "database": "bemidb"},
-	})
-	if err := frontend.Flush(); err != nil {
-		t.Fatalf("startup flush: %v", err)
-	}
-	for {
-		msg, err := frontend.Receive()
-		if err != nil {
-			t.Fatalf("startup receive: %v", err)
-		}
-		if _, ok := msg.(*pgproto3.ReadyForQuery); ok {
-			break
-		}
-	}
-
-	// receiveUntilReady drains one exchange's replies, reporting what was seen.
-	receiveUntilReady := func(step string) (sawRows bool, sawError bool) {
-		for {
-			msg, err := frontend.Receive()
-			if err != nil {
-				t.Fatalf("%s: receive error (server likely crashed): %v", step, err)
-			}
-			switch msg.(type) {
-			case *pgproto3.DataRow:
-				sawRows = true
-			case *pgproto3.ErrorResponse:
-				sawError = true
-			case *pgproto3.ReadyForQuery:
-				return sawRows, sawError
-			}
-		}
-	}
+	frontend, done := startTestPostgresClient(t, queryHandler)
 
 	fullExchange := func(step string) {
 		frontend.Send(&pgproto3.Parse{Query: "SELECT 1"})
@@ -193,7 +145,7 @@ func TestExtendedQueryStatementLifecycle(t *testing.T) {
 		if err := frontend.Flush(); err != nil {
 			t.Fatalf("%s: flush: %v", step, err)
 		}
-		sawRows, sawError := receiveUntilReady(step)
+		sawRows, sawError := receiveUntilReady(t, frontend, step)
 		if !sawRows || sawError {
 			t.Fatalf("%s: expected data rows and no error, got rows=%v error=%v", step, sawRows, sawError)
 		}
@@ -204,7 +156,7 @@ func TestExtendedQueryStatementLifecycle(t *testing.T) {
 	fullExchange("first exchange")
 	fullExchange("second exchange")
 
-	// Wire-protocol Close releases the statement mid-exchange; the following
+	// Wire-protocol Close('S') releases the statement mid-exchange; the following
 	// Describe must be answered with an error — previously this shape could only
 	// crash or silently leak. The connection must survive to the next exchange.
 	frontend.Send(&pgproto3.Parse{Query: "SELECT 1"})
@@ -217,19 +169,42 @@ func TestExtendedQueryStatementLifecycle(t *testing.T) {
 	}
 	// writeError sends its own ReadyForQuery (pre-existing behavior) and Sync sends
 	// another — drain both so the next exchange starts on a clean stream.
-	_, sawErrorOnError := receiveUntilReady("close exchange (error reply)")
-	_, sawErrorOnSync := receiveUntilReady("close exchange (sync reply)")
+	_, sawErrorOnError := receiveUntilReady(t, frontend, "close exchange (error reply)")
+	_, sawErrorOnSync := receiveUntilReady(t, frontend, "close exchange (sync reply)")
 	if !sawErrorOnError && !sawErrorOnSync {
-		t.Errorf("expected an error for Describe after wire-protocol Close")
+		t.Errorf("expected an error for Describe after wire-protocol Close('S')")
 	}
 
 	fullExchange("exchange after wire Close")
 
-	frontend.Send(&pgproto3.Terminate{})
-	_ = frontend.Flush()
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatalf("Run did not return after Terminate — connection loop wedged or panicked")
+	terminateAndAwait(t, frontend, done)
+}
+
+// TestWireClosePortalKeepsStatementBindable pins Postgres Close semantics:
+// Close('P') releases only the portal — the statement must remain bindable and
+// executable afterwards (JDBC cursor clients close portals mid-exchange and
+// Bind again). A regression here surfaced as "prepared statement was already
+// closed" on the second Execute.
+func TestWireClosePortalKeepsStatementBindable(t *testing.T) {
+	createTestTables(t)
+	queryHandler := initQueryHandler()
+	defer queryHandler.duckdb.Close()
+	frontend, done := startTestPostgresClient(t, queryHandler)
+
+	frontend.Send(&pgproto3.Parse{Query: "SELECT 1"})
+	frontend.Send(&pgproto3.Bind{})
+	frontend.Send(&pgproto3.Execute{})
+	frontend.Send(&pgproto3.Close{ObjectType: 'P'})
+	frontend.Send(&pgproto3.Bind{})
+	frontend.Send(&pgproto3.Execute{})
+	frontend.Send(&pgproto3.Sync{})
+	if err := frontend.Flush(); err != nil {
+		t.Fatalf("portal close exchange: flush: %v", err)
 	}
+	sawRows, sawError := receiveUntilReady(t, frontend, "portal close exchange")
+	if !sawRows || sawError {
+		t.Fatalf("expected rebind after Close('P') to succeed, got rows=%v error=%v", sawRows, sawError)
+	}
+
+	terminateAndAwait(t, frontend, done)
 }

--- a/src/postgres_test.go
+++ b/src/postgres_test.go
@@ -108,3 +108,128 @@ func TestRunDoesNotPanicOnErrorBeforeSync(t *testing.T) {
 		t.Fatalf("Run did not return after Terminate — connection loop wedged or panicked")
 	}
 }
+
+// TestExtendedQueryStatementLifecycle drives the paths where prepared statements
+// are now released (they previously leaked their DuckDB plan on every exchange):
+// two full exchanges back-to-back (deferred Close between them must not break the
+// connection), then a wire-protocol Close followed by a Describe on the released
+// statement (must error, not crash), then a final full exchange proving the
+// connection still serves.
+func TestExtendedQueryStatementLifecycle(t *testing.T) {
+	createTestTables(t)
+	queryHandler := initQueryHandler()
+	defer queryHandler.duckdb.Close()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+
+	done := make(chan struct{})
+	go func() {
+		serverConn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			close(done)
+			return
+		}
+		postgres := NewPostgres(queryHandler.config, &serverConn)
+		postgres.Run(queryHandler)
+		serverConn.Close()
+		close(done)
+	}()
+
+	clientConn, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer clientConn.Close()
+	if err := clientConn.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+
+	frontend := pgproto3.NewFrontend(clientConn, clientConn)
+	frontend.Send(&pgproto3.StartupMessage{
+		ProtocolVersion: pgproto3.ProtocolVersionNumber,
+		Parameters:      map[string]string{"user": "bemidb", "database": "bemidb"},
+	})
+	if err := frontend.Flush(); err != nil {
+		t.Fatalf("startup flush: %v", err)
+	}
+	for {
+		msg, err := frontend.Receive()
+		if err != nil {
+			t.Fatalf("startup receive: %v", err)
+		}
+		if _, ok := msg.(*pgproto3.ReadyForQuery); ok {
+			break
+		}
+	}
+
+	// receiveUntilReady drains one exchange's replies, reporting what was seen.
+	receiveUntilReady := func(step string) (sawRows bool, sawError bool) {
+		for {
+			msg, err := frontend.Receive()
+			if err != nil {
+				t.Fatalf("%s: receive error (server likely crashed): %v", step, err)
+			}
+			switch msg.(type) {
+			case *pgproto3.DataRow:
+				sawRows = true
+			case *pgproto3.ErrorResponse:
+				sawError = true
+			case *pgproto3.ReadyForQuery:
+				return sawRows, sawError
+			}
+		}
+	}
+
+	fullExchange := func(step string) {
+		frontend.Send(&pgproto3.Parse{Query: "SELECT 1"})
+		frontend.Send(&pgproto3.Bind{})
+		frontend.Send(&pgproto3.Describe{ObjectType: 'P'})
+		frontend.Send(&pgproto3.Execute{})
+		frontend.Send(&pgproto3.Sync{})
+		if err := frontend.Flush(); err != nil {
+			t.Fatalf("%s: flush: %v", step, err)
+		}
+		sawRows, sawError := receiveUntilReady(step)
+		if !sawRows || sawError {
+			t.Fatalf("%s: expected data rows and no error, got rows=%v error=%v", step, sawRows, sawError)
+		}
+	}
+
+	// Two consecutive successful exchanges: the deferred statement release after
+	// the first must not affect the second.
+	fullExchange("first exchange")
+	fullExchange("second exchange")
+
+	// Wire-protocol Close releases the statement mid-exchange; the following
+	// Describe must be answered with an error — previously this shape could only
+	// crash or silently leak. The connection must survive to the next exchange.
+	frontend.Send(&pgproto3.Parse{Query: "SELECT 1"})
+	frontend.Send(&pgproto3.Close{ObjectType: 'S'})
+	frontend.Send(&pgproto3.Describe{ObjectType: 'S'})
+	frontend.Send(&pgproto3.Execute{})
+	frontend.Send(&pgproto3.Sync{})
+	if err := frontend.Flush(); err != nil {
+		t.Fatalf("close exchange: flush: %v", err)
+	}
+	// writeError sends its own ReadyForQuery (pre-existing behavior) and Sync sends
+	// another — drain both so the next exchange starts on a clean stream.
+	_, sawErrorOnError := receiveUntilReady("close exchange (error reply)")
+	_, sawErrorOnSync := receiveUntilReady("close exchange (sync reply)")
+	if !sawErrorOnError && !sawErrorOnSync {
+		t.Errorf("expected an error for Describe after wire-protocol Close")
+	}
+
+	fullExchange("exchange after wire Close")
+
+	frontend.Send(&pgproto3.Terminate{})
+	_ = frontend.Flush()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Run did not return after Terminate — connection loop wedged or panicked")
+	}
+}

--- a/src/postgres_test.go
+++ b/src/postgres_test.go
@@ -180,6 +180,33 @@ func TestExtendedQueryStatementLifecycle(t *testing.T) {
 	terminateAndAwait(t, frontend, done)
 }
 
+// TestWireCloseUnknownNameIsNoOp pins the name check: pgjdbc statement-cache
+// evictions interleave Close('S', "old_name") into the current exchange —
+// closing a name that isn't the current statement must be a CloseComplete
+// no-op, not destroy the statement the client is actively using.
+func TestWireCloseUnknownNameIsNoOp(t *testing.T) {
+	createTestTables(t)
+	queryHandler := initQueryHandler()
+	defer queryHandler.duckdb.Close()
+	frontend, done := startTestPostgresClient(t, queryHandler)
+
+	frontend.Send(&pgproto3.Parse{Name: "S_2", Query: "SELECT 1"})
+	frontend.Send(&pgproto3.Close{ObjectType: 'S', Name: "S_1"}) // evicting an older statement
+	frontend.Send(&pgproto3.Bind{PreparedStatement: "S_2"})
+	frontend.Send(&pgproto3.Describe{ObjectType: 'P'})
+	frontend.Send(&pgproto3.Execute{})
+	frontend.Send(&pgproto3.Sync{})
+	if err := frontend.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	sawRows, sawError := receiveUntilReady(t, frontend, "close unknown name")
+	if !sawRows || sawError {
+		t.Fatalf("expected S_2 to survive Close('S', \"S_1\"), got rows=%v error=%v", sawRows, sawError)
+	}
+
+	terminateAndAwait(t, frontend, done)
+}
+
 // TestWireClosePortalKeepsStatementBindable pins Postgres Close semantics:
 // Close('P') releases only the portal — the statement must remain bindable and
 // executable afterwards (JDBC cursor clients close portals mid-exchange and

--- a/src/prepared_statement_test.go
+++ b/src/prepared_statement_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgproto3"
+)
+
+func TestPreparedStatementClose(t *testing.T) {
+	queryHandler := initQueryHandler()
+	defer queryHandler.duckdb.Close()
+
+	t.Run("nil receiver", func(t *testing.T) {
+		var preparedStatement *PreparedStatement
+		preparedStatement.Close() // must not panic
+	})
+
+	t.Run("empty statement (no driver statement)", func(t *testing.T) {
+		preparedStatement := &PreparedStatement{Name: "empty"}
+		preparedStatement.Close() // must not panic
+	})
+
+	t.Run("closes statement and is idempotent", func(t *testing.T) {
+		statement, err := queryHandler.duckdb.PrepareContext(context.Background(), "SELECT 1")
+		if err != nil {
+			t.Fatalf("prepare: %v", err)
+		}
+		preparedStatement := &PreparedStatement{Statement: statement}
+		preparedStatement.Close()
+		if preparedStatement.Statement != nil {
+			t.Errorf("expected Statement to be nil after Close")
+		}
+		preparedStatement.Close() // second Close must not panic
+
+		// The driver-side handle must actually be released: using the original
+		// statement now fails instead of silently working against a live plan.
+		if _, err := statement.QueryContext(context.Background()); err == nil {
+			t.Errorf("expected query on closed statement to fail")
+		}
+	})
+
+	t.Run("closes open rows before the statement", func(t *testing.T) {
+		statement, err := queryHandler.duckdb.PrepareContext(context.Background(), "SELECT 1")
+		if err != nil {
+			t.Fatalf("prepare: %v", err)
+		}
+		rows, err := statement.QueryContext(context.Background())
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		preparedStatement := &PreparedStatement{Statement: statement, Rows: rows}
+		preparedStatement.Close() // must not panic or deadlock with rows open
+		if preparedStatement.Rows != nil || preparedStatement.Statement != nil {
+			t.Errorf("expected Rows and Statement to be nil after Close")
+		}
+	})
+}
+
+// After a wire-protocol Close releases the statement, Describe and Execute on it
+// must return an error (like Postgres' "prepared statement does not exist"), not
+// dereference the nil Statement and crash the process.
+func TestDescribeAndExecuteAfterStatementClosed(t *testing.T) {
+	queryHandler := initQueryHandler()
+	defer queryHandler.duckdb.Close()
+
+	preparedStatement := &PreparedStatement{
+		OriginalQuery: "SELECT 1",
+		Query:         "SELECT 1",
+		Bound:         true,
+		Statement:     nil, // released by PreparedStatement.Close()
+	}
+
+	if _, _, err := queryHandler.HandleDescribeQuery(&pgproto3.Describe{ObjectType: 'P'}, preparedStatement); err == nil {
+		t.Errorf("expected Describe on closed statement to error")
+	}
+	if _, err := queryHandler.HandleExecuteQuery(&pgproto3.Execute{}, preparedStatement); err == nil {
+		t.Errorf("expected Execute on closed statement to error")
+	}
+}

--- a/src/query_handler.go
+++ b/src/query_handler.go
@@ -52,6 +52,27 @@ type PreparedStatement struct {
 	Rows *sql.Rows
 }
 
+// Close releases the driver-side resources this statement pins. database/sql
+// requires it ("The caller must call the statement's Close method when the
+// statement is no longer needed"), and go-duckdb has no finalizer: an unclosed
+// statement keeps its bound plan alive in DuckDB's C++ memory — invisible to
+// both the Go heap and duckdb_memory() — for the life of its pooled connection.
+// Rows close first so the driver doesn't defer the statement close behind an
+// open result. Nil-safe and idempotent.
+func (preparedStatement *PreparedStatement) Close() {
+	if preparedStatement == nil {
+		return
+	}
+	if preparedStatement.Rows != nil {
+		preparedStatement.Rows.Close()
+		preparedStatement.Rows = nil
+	}
+	if preparedStatement.Statement != nil {
+		preparedStatement.Statement.Close()
+		preparedStatement.Statement = nil
+	}
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 type NullDecimal struct {
@@ -469,6 +490,9 @@ func (queryHandler *QueryHandler) HandleDescribeQuery(message *pgproto3.Describe
 	if preparedStatement.Query == "" || !preparedStatement.Bound { // Empty query or Parse->[No Bind]->Describe
 		return []pgproto3.Message{&pgproto3.NoData{}}, preparedStatement, nil
 	}
+	if preparedStatement.Statement == nil { // Statement released by a wire-protocol Close
+		return nil, nil, fmt.Errorf("prepared statement was already closed: %s", preparedStatement.OriginalQuery)
+	}
 
 	rows, err := preparedStatement.Statement.QueryContext(context.Background(), preparedStatement.Variables...)
 	if err != nil {
@@ -493,6 +517,9 @@ func (queryHandler *QueryHandler) HandleExecuteQuery(message *pgproto3.Execute, 
 	}
 
 	if preparedStatement.Rows == nil { // Parse->[No Bind]->Describe->Execute or Parse->Bind->[No Describe]->Execute
+		if preparedStatement.Statement == nil { // Statement released by a wire-protocol Close
+			return nil, fmt.Errorf("prepared statement was already closed: %s", preparedStatement.OriginalQuery)
+		}
 		rows, err := preparedStatement.Statement.QueryContext(context.Background(), preparedStatement.Variables...)
 		if err != nil {
 			return nil, err

--- a/src/query_handler.go
+++ b/src/query_handler.go
@@ -386,7 +386,7 @@ func (queryHandler *QueryHandler) HandleBindQuery(message *pgproto3.Bind, prepar
 	}
 
 	if message.PreparedStatement != preparedStatement.Name {
-		return nil, nil, fmt.Errorf("prepared statement mismatch, %s instead of %s: %s", message.PreparedStatement, preparedStatement.Name, preparedStatement.OriginalQuery)
+		return nil, preparedStatement, fmt.Errorf("prepared statement mismatch, %s instead of %s: %s", message.PreparedStatement, preparedStatement.Name, preparedStatement.OriginalQuery)
 	}
 
 	var variables []interface{}
@@ -407,7 +407,7 @@ func (queryHandler *QueryHandler) HandleBindQuery(message *pgproto3.Bind, prepar
 		if textFormat {
 			val, err := castTextParam(string(param), preparedStatement.ParameterOIDs, i)
 			if err != nil {
-				return nil, nil, fmt.Errorf("failed to cast parameter %d: %w. Original query: %s", i, err, preparedStatement.OriginalQuery)
+				return nil, preparedStatement, fmt.Errorf("failed to cast parameter %d: %w. Original query: %s", i, err, preparedStatement.OriginalQuery)
 			}
 			variables = append(variables, val)
 		} else if len(param) == 4 {
@@ -417,7 +417,7 @@ func (queryHandler *QueryHandler) HandleBindQuery(message *pgproto3.Bind, prepar
 		} else if len(param) == 16 {
 			variables = append(variables, uuid.UUID(param).String())
 		} else {
-			return nil, nil, fmt.Errorf("unsupported parameter format: %v (length %d). Original query: %s", param, len(param), preparedStatement.OriginalQuery)
+			return nil, preparedStatement, fmt.Errorf("unsupported parameter format: %v (length %d). Original query: %s", param, len(param), preparedStatement.OriginalQuery)
 		}
 	}
 
@@ -467,9 +467,9 @@ func castTextParam(text string, parameterOIDs []uint32, index int) (interface{},
 
 func (queryHandler *QueryHandler) HandleDescribeQuery(message *pgproto3.Describe, preparedStatement *PreparedStatement) ([]pgproto3.Message, *PreparedStatement, error) {
 	// A repeat Describe would otherwise leak the prior result handle until GC
-	// (mirrors the reset in HandleBindQuery). Like there, this must run before
-	// every error return: on error the caller nils the statement, orphaning
-	// still-open rows beyond the reach of Sync's cleanup.
+	// (mirrors the reset in HandleBindQuery). Error returns hand the statement
+	// back to the caller, so anything still open here stays reachable by the
+	// caller's deferred Close.
 	if preparedStatement.Rows != nil {
 		preparedStatement.Rows.Close()
 		preparedStatement.Rows = nil
@@ -478,11 +478,11 @@ func (queryHandler *QueryHandler) HandleDescribeQuery(message *pgproto3.Describe
 	switch message.ObjectType {
 	case 'S': // Statement
 		if message.Name != preparedStatement.Name {
-			return nil, nil, fmt.Errorf("statement mismatch, %s instead of %s: %s", message.Name, preparedStatement.Name, preparedStatement.OriginalQuery)
+			return nil, preparedStatement, fmt.Errorf("statement mismatch, %s instead of %s: %s", message.Name, preparedStatement.Name, preparedStatement.OriginalQuery)
 		}
 	case 'P': // Portal
 		if message.Name != preparedStatement.Portal {
-			return nil, nil, fmt.Errorf("portal mismatch, %s instead of %s: %s", message.Name, preparedStatement.Portal, preparedStatement.OriginalQuery)
+			return nil, preparedStatement, fmt.Errorf("portal mismatch, %s instead of %s: %s", message.Name, preparedStatement.Portal, preparedStatement.OriginalQuery)
 		}
 	}
 
@@ -491,18 +491,18 @@ func (queryHandler *QueryHandler) HandleDescribeQuery(message *pgproto3.Describe
 		return []pgproto3.Message{&pgproto3.NoData{}}, preparedStatement, nil
 	}
 	if preparedStatement.Statement == nil { // Statement released by a wire-protocol Close
-		return nil, nil, fmt.Errorf("prepared statement was already closed: %s", preparedStatement.OriginalQuery)
+		return nil, preparedStatement, fmt.Errorf("prepared statement was already closed: %s", preparedStatement.OriginalQuery)
 	}
 
 	rows, err := preparedStatement.Statement.QueryContext(context.Background(), preparedStatement.Variables...)
 	if err != nil {
-		return nil, nil, fmt.Errorf("couldn't execute statement: %w. Original query: %s", err, preparedStatement.OriginalQuery)
+		return nil, preparedStatement, fmt.Errorf("couldn't execute statement: %w. Original query: %s", err, preparedStatement.OriginalQuery)
 	}
 	preparedStatement.Rows = rows
 
 	messages, err := queryHandler.rowsToDescriptionMessages(preparedStatement.Rows, preparedStatement.OriginalQuery)
 	if err != nil {
-		return nil, nil, err
+		return nil, preparedStatement, err
 	}
 	return messages, preparedStatement, nil
 }

--- a/src/query_handler.go
+++ b/src/query_handler.go
@@ -377,9 +377,8 @@ func (queryHandler *QueryHandler) HandleParseQuery(message *pgproto3.Parse) ([]p
 func (queryHandler *QueryHandler) HandleBindQuery(message *pgproto3.Bind, preparedStatement *PreparedStatement) ([]pgproto3.Message, *PreparedStatement, error) {
 	// Bind creates a new portal: results from a previous Bind/Describe of this
 	// statement must not leak into it (a follow-up Execute would reuse them via
-	// the Rows != nil branch). This must run before every error return: on error
-	// the caller nils the statement, orphaning still-open rows beyond the reach
-	// of Sync's cleanup.
+	// the Rows != nil branch). Error returns hand the statement back to the
+	// caller, so anything still open stays reachable by the deferred Close.
 	if preparedStatement.Rows != nil {
 		preparedStatement.Rows.Close()
 		preparedStatement.Rows = nil


### PR DESCRIPTION
## The problem

Production pods OOM-kill every ~46 hours (4 kills in the last 7.6 days). The PR #8 gauges finally showed why: RSS ratchets up while both bounded ledgers stay near-empty — at the Aug-18 kill the pod was at **8191 MiB RSS with go_heap=112 MiB and duckdb=191 MiB**. The growth is untracked C++ memory that none of the existing caps (memory_limit, threads, max-result-mb) can see. Two compounding mechanisms, both verified by experiment:

### 1. Prepared statements were never closed (real leak)

`database/sql` requires it (*"The caller must call the statement's Close method when the statement is no longer needed"*), go-duckdb has no finalizer (`duckdb_destroy_prepare` happens only in `Stmt.Close`), and the codebase had **one `PrepareContext` and zero `stmt.Close()`** — so every extended-protocol query leaked its bound DuckDB plan for the life of its pooled connection. Metabase's schema sweep alone (148 probes, hourly at :06) left ~+40–50 MiB permanently each hour, measured in the dying container's sampler log.

**Fix:** statements are released on every exit of `handleExtendedQuery` (deferred — covers the Sync return, dead connections, and panics) and on the wire-protocol `Close` message. Error paths now keep ownership of the live statement instead of overwriting it with the handlers' `nil` returns — which also fixes a documented pre-existing gap where error paths orphaned open rows. `Describe`/`Execute` on a closed statement return a proper error (like Postgres' "prepared statement does not exist") instead of a nil-deref crash.

### 2. jemalloc retention (unbounded-in-practice)

DuckDB's bundled jemalloc keeps freed memory pooled indefinitely by default — deliberate upstream for embedded use ([maintainer: "DuckDB is an in-process database system, not a database server"](https://github.com/duckdb/duckdb/discussions/11455)), wrong for a long-lived server. Measured on this exact engine (v1.8.3 / DuckDB 1.1.3, prod limits): a 24-round scan workload retained **1182 MiB at full idle with defaults vs 73 MiB** with background purge + lower flush threshold; separately, retention pins to long-lived connections and is fully released when they close.

**Fix:** three new knobs, defaults = the fix, all env/flag tunable:

| Env / flag | Default | Effect |
|---|---|---|
| `BEMIDB_DUCKDB_ALLOCATOR_BACKGROUND_THREADS` / `--duckdb-allocator-background-threads` | `true` | jemalloc purge threads return freed pages to the OS (`false` restores DuckDB default) |
| `BEMIDB_DUCKDB_ALLOCATOR_FLUSH_THRESHOLD` / `--duckdb-allocator-flush-threshold` | `64MB` | post-task allocator flush kicks in for mid-size queries (DuckDB default 128MB; empty leaves default) |
| `BEMIDB_DUCKDB_CONN_MAX_LIFETIME_MINUTES` / `--duckdb-conn-max-lifetime-minutes` | `30` | recycle pooled DuckDB connections between uses — never mid-query (0 disables) |

Both SETs verified accepted on Linux (jemalloc build) and macOS (no jemalloc — no-op), so boot stays portable.

## Verification

- `TestPreparedStatementClose` — nil receiver, empty statement, double-close idempotence, rows-then-statement ordering, and that the driver handle is really released.
- `TestDescribeAndExecuteAfterStatementClosed` — the new guards error instead of crashing.
- `TestExtendedQueryStatementLifecycle` — real TCP + real DuckDB through the actual `Run` loop: two consecutive exchanges (deferred release must not break the connection), wire `Close` mid-exchange followed by `Describe` (error, connection survives), full exchange after, clean `Terminate`.
- Full suite green in `golang:1.24.3` (`-skip '^TestHandleQuery$'`, pre-existing failure).
- Controlled experiments: 120 unclosed prepares = flat RSS locally (plan cost is KB-scale for parquet; prod's hourly +40–50 MiB bounds the iceberg-side cost), allocator knobs = 16× idle-retention reduction.

## Acceptance criteria (on the PR #8 gauges, within a day of deploy)

1. An hourly Metabase schema sweep moves `untracked` by ~0 instead of +40–50 MiB.
2. After heavy scan bursts, RSS returns toward baseline instead of ratcheting.
3. The ~46h OOM-kill cadence stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)